### PR TITLE
feat(transit): offline-bundle download endpoint + data_revision staleness

### DIFF
--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -94,6 +94,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'directions': '30/min',
+        'offline-bundle': '12/min',
         'marketplace_write': '20/min',
         'traffic_write': '30/min',
     },

--- a/src/transit/api_v3.py
+++ b/src/transit/api_v3.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from tenancy.services import for_island
 from transit.models import Trip
 from transit.services.directions_v3 import get_directions_v3
+from transit.services.offline_bundle import compute_bundle_version, get_offline_bundle_cached
 from transit.services.v3 import (
     get_line_v3,
     get_trip_v3,
@@ -18,7 +19,7 @@ from transit.services.v3 import (
     serialize_stops_v3,
     serialize_trip_detail,
 )
-from transit.throttling import DirectionsSessionThrottle
+from transit.throttling import DirectionsSessionThrottle, OfflineBundleThrottle
 
 
 def _require_island(request: Request) -> Response | None:
@@ -41,6 +42,47 @@ def transit_stops_view(request: Request) -> Response:
 
         stops = Stop.objects.all().order_by('name')
         return Response({'stops': serialize_stops_v3(stops)})
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def transit_offline_version_view(request: Request) -> Response:
+    """Lightweight staleness probe — client polls this before downloading."""
+    err = _require_island(request)
+    if err:
+        return err
+    with for_island(request.island):
+        version = compute_bundle_version(request.island)
+    return Response({'version': version, 'island': request.island.key})
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+@throttle_classes([OfflineBundleThrottle])
+def transit_offline_bundle_view(request: Request) -> Response:
+    """Self-contained transit dataset for offline route search.
+
+    Supports conditional GET via ETag (secondary to the /version poll): a client
+    that sends a matching If-None-Match gets 304 without the payload.
+    """
+    err = _require_island(request)
+    if err:
+        return err
+
+    with for_island(request.island):
+        version = compute_bundle_version(request.island)
+        if_none_match = request.headers.get('If-None-Match', '').strip().strip('"')
+        if if_none_match and if_none_match == version:
+            not_modified = Response(status=status.HTTP_304_NOT_MODIFIED)
+            not_modified['ETag'] = f'"{version}"'
+            return not_modified
+
+        bundle = get_offline_bundle_cached(request.island)
+
+    response = Response(bundle)
+    response['ETag'] = f'"{bundle["version"]}"'
+    response['Cache-Control'] = 'no-cache'
+    return response
 
 
 @api_view(['GET'])

--- a/src/transit/apps.py
+++ b/src/transit/apps.py
@@ -5,3 +5,8 @@ class TransitConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'transit'
     verbose_name = 'Transit schedules'
+
+    def ready(self) -> None:
+        from transit.signals import register_transit_signals
+
+        register_transit_signals()

--- a/src/transit/services/legacy_import.py
+++ b/src/transit/services/legacy_import.py
@@ -993,7 +993,11 @@ def run_full_import(
         legacy = open_legacy_source(legacy_db_url=legacy_db_url, export_file=export_file)
 
     # Imported lazily to avoid a circular import (offline_bundle → v3 → search → legacy_import).
-    from transit.services.offline_bundle import bump_data_revision, suppress_revision_bumps
+    from transit.services.offline_bundle import (
+        bump_data_revision,
+        prewarm_offline_bundle,
+        suppress_revision_bumps,
+    )
 
     with suppress_revision_bumps():
         for step in order:
@@ -1006,6 +1010,9 @@ def run_full_import(
                 on_step_complete(report)
 
     # Single revision bump after a bulk import so offline clients detect new data
-    # without thousands of per-row writes during the import itself.
+    # without thousands of per-row writes during the import itself, then warm the
+    # bundle cache so the first client download does not pay the rebuild cost.
     bump_data_revision(island.id)
+    island.refresh_from_db()
+    prewarm_offline_bundle(island)
     return reports

--- a/src/transit/services/legacy_import.py
+++ b/src/transit/services/legacy_import.py
@@ -992,12 +992,20 @@ def run_full_import(
     if legacy is None:
         legacy = open_legacy_source(legacy_db_url=legacy_db_url, export_file=export_file)
 
-    for step in order:
-        if on_step_start:
-            on_step_start(step)
-        report = MIGRATION_STEPS[step](island, legacy)
-        write_report(report)
-        reports.append(report)
-        if on_step_complete:
-            on_step_complete(report)
+    # Imported lazily to avoid a circular import (offline_bundle → v3 → search → legacy_import).
+    from transit.services.offline_bundle import bump_data_revision, suppress_revision_bumps
+
+    with suppress_revision_bumps():
+        for step in order:
+            if on_step_start:
+                on_step_start(step)
+            report = MIGRATION_STEPS[step](island, legacy)
+            write_report(report)
+            reports.append(report)
+            if on_step_complete:
+                on_step_complete(report)
+
+    # Single revision bump after a bulk import so offline clients detect new data
+    # without thousands of per-row writes during the import itself.
+    bump_data_revision(island.id)
     return reports

--- a/src/transit/services/offline_bundle.py
+++ b/src/transit/services/offline_bundle.py
@@ -11,16 +11,22 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import hashlib
+import time as _time
 
+from django.core.cache import cache
 from django.db import transaction
 from django.utils import timezone
 
 from tenancy.models import Island
+from tenancy.services import for_island
 from transit.models import Holiday, Stop, Trip
 from transit.services.compat import _serialize_active_infos, _trip_to_load_route
 from transit.services.v3 import serialize_stops_v3
 
 _REVISION_FLAG = 'data_revision'
+
+_BUNDLE_CACHE_TTL = 24 * 3600
+_BUNDLE_LOCK_TTL = 30
 
 # Set during bulk imports so per-row writes do not each trigger a revision bump;
 # callers issue a single bump after the import completes.
@@ -109,3 +115,48 @@ def build_offline_bundle(island: Island) -> dict:
         'infos': _serialize_active_infos(),
         'routes': routes,
     }
+
+
+def _bundle_cache_key(island_key: str, version: str) -> str:
+    return f'transit:offline:bundle:{island_key}:{version}'
+
+
+def get_offline_bundle_cached(island: Island) -> dict:
+    """Return the offline bundle, served from Redis when warm.
+
+    Keyed by version: a data change produces a new version (cache miss → rebuild)
+    while stale entries expire naturally. A single-flight lock prevents a rebuild
+    stampede when many clients request a cold version at once.
+    """
+    with for_island(island):
+        version = compute_bundle_version(island)
+        cache_key = _bundle_cache_key(island.key, version)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        lock_key = f'transit:offline:lock:{island.key}'
+        if cache.add(lock_key, '1', _BUNDLE_LOCK_TTL):
+            try:
+                bundle = build_offline_bundle(island)
+                cache.set(cache_key, bundle, _BUNDLE_CACHE_TTL)
+                return bundle
+            finally:
+                cache.delete(lock_key)
+
+        # Another worker is building; briefly wait for it to populate the cache.
+        for _ in range(30):
+            _time.sleep(0.1)
+            cached = cache.get(cache_key)
+            if cached is not None:
+                return cached
+        # Fallback: build without caching rather than block the client.
+        return build_offline_bundle(island)
+
+
+def prewarm_offline_bundle(island: Island) -> None:
+    """Best-effort cache warmup (e.g. after a bulk import)."""
+    try:
+        get_offline_bundle_cached(island)
+    except Exception:  # pragma: no cover - warmup must never break the caller
+        pass

--- a/src/transit/services/offline_bundle.py
+++ b/src/transit/services/offline_bundle.py
@@ -1,0 +1,111 @@
+"""Offline transit bundle serialization + data-revision staleness signal.
+
+The mobile client downloads a single self-contained bundle for offline route
+search. ``data_revision`` is a write-triggered counter (bumped by model signals
+on any schedule-bearing change) that gives a deterministic staleness signal
+without hashing the whole dataset on every request.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import hashlib
+
+from django.db import transaction
+from django.utils import timezone
+
+from tenancy.models import Island
+from transit.models import Holiday, Stop, Trip
+from transit.services.compat import _serialize_active_infos, _trip_to_load_route
+from transit.services.v3 import serialize_stops_v3
+
+_REVISION_FLAG = 'data_revision'
+
+# Set during bulk imports so per-row writes do not each trigger a revision bump;
+# callers issue a single bump after the import completes.
+_suppress_bumps: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    'transit_suppress_revision_bumps', default=False
+)
+
+
+@contextlib.contextmanager
+def suppress_revision_bumps():
+    token = _suppress_bumps.set(True)
+    try:
+        yield
+    finally:
+        _suppress_bumps.reset(token)
+
+
+def revision_bumps_suppressed() -> bool:
+    return _suppress_bumps.get()
+
+
+def get_data_revision(island: Island) -> int:
+    flags = island.feature_flags or {}
+    try:
+        return int(flags.get(_REVISION_FLAG, 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def bump_data_revision(island_id: int) -> int:
+    """Atomically increment the island's transit data revision.
+
+    Low-concurrency path (admin edits / end-of-import), so a select-for-update
+    read-modify-write on the ``feature_flags`` JSON is acceptable.
+    """
+    with transaction.atomic():
+        island = Island.objects.select_for_update().get(pk=island_id)
+        flags = dict(island.feature_flags or {})
+        try:
+            current = int(flags.get(_REVISION_FLAG, 0))
+        except (TypeError, ValueError):
+            current = 0
+        next_revision = current + 1
+        flags[_REVISION_FLAG] = next_revision
+        island.feature_flags = flags
+        island.save(update_fields=['feature_flags', 'updated_at'])
+    return next_revision
+
+
+def compute_bundle_version(island: Island) -> str:
+    """Deterministic version fingerprint for the offline bundle.
+
+    Folds the write-triggered revision together with cheap row counts so that
+    the fingerprint changes on any schedule mutation even if a revision write
+    was somehow missed.
+    """
+    revision = get_data_revision(island)
+    stops_count = Stop.objects.count()
+    routes_count = Trip.objects.filter(source=Trip.SOURCE_OPERATOR).count()
+    raw = f'{island.key}:{revision}:{stops_count}:{routes_count}'
+    return hashlib.sha256(raw.encode('utf-8')).hexdigest()[:16]
+
+
+def build_offline_bundle(island: Island) -> dict:
+    """Self-contained transit dataset for offline route search."""
+    holidays = [
+        {'id': h.id, 'date': h.date.isoformat(), 'name': h.name}
+        for h in Holiday.objects.all().order_by('date')
+    ]
+    stops = serialize_stops_v3(Stop.objects.all().order_by('name'))
+    trips = (
+        Trip.objects.filter(source=Trip.SOURCE_OPERATOR)
+        .select_related('line', 'calendar')
+        .exclude(line__disabled=True)
+    )
+    routes = [_trip_to_load_route(trip) for trip in trips]
+    flags = island.feature_flags or {}
+    return {
+        'version': compute_bundle_version(island),
+        'generatedAt': timezone.now().isoformat(),
+        'island': island.key,
+        'maps': flags.get('maps', False),
+        'counts': {'stops': Stop.objects.count(), 'routes': len(routes)},
+        'stops': stops,
+        'holidays': holidays,
+        'infos': _serialize_active_infos(),
+        'routes': routes,
+    }

--- a/src/transit/signals.py
+++ b/src/transit/signals.py
@@ -1,0 +1,50 @@
+"""Write-triggered ``data_revision`` bumps for offline-bundle staleness.
+
+Any schedule-bearing change to transit data bumps the owning island's
+``data_revision`` so the mobile client's offline bundle is detected as stale.
+Vote-only ``Trip`` saves (likes/dislikes) are excluded — they do not affect
+schedules and would otherwise invalidate every offline cache on every vote.
+"""
+
+from __future__ import annotations
+
+from django.db.models.signals import post_delete, post_save
+
+from transit.models import Calendar, Holiday, Line, RouteInfo, Stop, StopTime, Trip
+from transit.services.offline_bundle import bump_data_revision, revision_bumps_suppressed
+
+_WATCHED = (Stop, Line, Trip, StopTime, Calendar, Holiday, RouteInfo)
+_VOTE_FIELDS = {'likes', 'dislikes'}
+
+
+def _maybe_bump(instance, update_fields=None) -> None:
+    if revision_bumps_suppressed():
+        return
+    if update_fields is not None and set(update_fields) <= _VOTE_FIELDS:
+        return
+    island_id = getattr(instance, 'island_id', None)
+    if island_id is None:
+        return
+    bump_data_revision(island_id)
+
+
+def _on_post_save(sender, instance, update_fields=None, **kwargs):
+    _maybe_bump(instance, update_fields)
+
+
+def _on_post_delete(sender, instance, **kwargs):
+    _maybe_bump(instance)
+
+
+def register_transit_signals() -> None:
+    for model in _WATCHED:
+        post_save.connect(
+            _on_post_save,
+            sender=model,
+            dispatch_uid=f'transit_rev_save_{model.__name__}',
+        )
+        post_delete.connect(
+            _on_post_delete,
+            sender=model,
+            dispatch_uid=f'transit_rev_del_{model.__name__}',
+        )

--- a/src/transit/tests/test_api_v3_offline_bundle.py
+++ b/src/transit/tests/test_api_v3_offline_bundle.py
@@ -1,0 +1,71 @@
+"""API tests for the v3 offline-bundle and version endpoints."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from transit.models import Stop
+from transit.tests.fixtures import ensure_transit_fixtures
+
+
+class OfflineBundleAPITests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.island, self.trip, self.line = ensure_transit_fixtures()
+        self.headers = {'HTTP_X_ISLAND': 'sao-miguel'}
+
+    def test_version_falls_back_to_default_island(self):
+        response = self.client.get('/api/v3/transit/offline-bundle/version')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['island'], 'sao-miguel')
+
+    def test_version_endpoint(self):
+        response = self.client.get('/api/v3/transit/offline-bundle/version', **self.headers)
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['island'], 'sao-miguel')
+        self.assertTrue(body['version'])
+
+    def test_bundle_endpoint_shape_and_etag(self):
+        response = self.client.get('/api/v3/transit/offline-bundle', **self.headers)
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        for key in ('version', 'island', 'stops', 'routes', 'holidays', 'infos', 'counts'):
+            self.assertIn(key, body)
+        self.assertEqual(response['ETag'], f'"{body["version"]}"')
+
+    def test_conditional_get_returns_304(self):
+        version = self.client.get(
+            '/api/v3/transit/offline-bundle/version', **self.headers
+        ).json()['version']
+        response = self.client.get(
+            '/api/v3/transit/offline-bundle',
+            HTTP_IF_NONE_MATCH=f'"{version}"',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 304)
+
+    def test_version_changes_after_data_edit(self):
+        v1 = self.client.get(
+            '/api/v3/transit/offline-bundle/version', **self.headers
+        ).json()['version']
+        Stop.objects.create(
+            island=self.island,
+            name='Lagoa',
+            cleaned_name='lagoa',
+            latitude=37.74,
+            longitude=-25.57,
+        )
+        v2 = self.client.get(
+            '/api/v3/transit/offline-bundle/version', **self.headers
+        ).json()['version']
+        self.assertNotEqual(v1, v2)
+
+        # Stale ETag no longer matches → full payload returned.
+        response = self.client.get(
+            '/api/v3/transit/offline-bundle',
+            HTTP_IF_NONE_MATCH=f'"{v1}"',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 200)

--- a/src/transit/tests/test_directions.py
+++ b/src/transit/tests/test_directions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.test import TestCase, override_settings
 
 from tenancy.services import get_or_create_default_island
@@ -13,6 +14,7 @@ from transit.services.directions_v3 import fetch_gmaps_directions, get_direction
 
 class DirectionsServiceTests(TestCase):
     def setUp(self):
+        cache.clear()
         self.island = get_or_create_default_island()
         self.island.feature_flags = {**(self.island.feature_flags or {}), 'maps': True}
         self.island.save(update_fields=['feature_flags'])

--- a/src/transit/tests/test_offline_bundle.py
+++ b/src/transit/tests/test_offline_bundle.py
@@ -1,0 +1,93 @@
+"""Tests for the offline bundle serializer and data-revision staleness signal."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from django.test import TestCase
+
+from tenancy.services import for_island
+from transit.models import Stop, StopTime
+from transit.services.offline_bundle import (
+    bump_data_revision,
+    build_offline_bundle,
+    compute_bundle_version,
+    get_data_revision,
+    suppress_revision_bumps,
+)
+from transit.tests.fixtures import ensure_transit_fixtures
+
+
+class OfflineBundleServiceTests(TestCase):
+    def setUp(self):
+        self.island, self.trip, self.line = ensure_transit_fixtures()
+
+    def _revision(self) -> int:
+        self.island.refresh_from_db()
+        return get_data_revision(self.island)
+
+    def test_bundle_has_expected_shape(self):
+        with for_island(self.island):
+            bundle = build_offline_bundle(self.island)
+        for key in ('version', 'generatedAt', 'island', 'maps', 'counts', 'stops', 'holidays', 'infos', 'routes'):
+            self.assertIn(key, bundle)
+        self.assertEqual(bundle['island'], 'sao-miguel')
+        self.assertGreater(len(bundle['routes']), 0)
+        self.assertGreater(bundle['counts']['stops'], 0)
+
+    def test_schedule_edit_bumps_revision(self):
+        before = self._revision()
+        stop = Stop.objects.create(
+            island=self.island,
+            name='Lagoa',
+            cleaned_name='lagoa',
+            latitude=37.74,
+            longitude=-25.57,
+        )
+        after_create = self._revision()
+        self.assertGreater(after_create, before)
+
+        StopTime.objects.create(
+            island=self.island,
+            trip=self.trip,
+            stop=stop,
+            sequence=3,
+            departure_time=time(10, 0),
+        )
+        self.assertGreater(self._revision(), after_create)
+
+    def test_vote_does_not_bump_revision(self):
+        before = self._revision()
+        self.trip.likes += 1
+        self.trip.save(update_fields=['likes'])
+        self.assertEqual(self._revision(), before)
+
+        self.trip.dislikes += 1
+        self.trip.save(update_fields=['dislikes'])
+        self.assertEqual(self._revision(), before)
+
+    def test_delete_bumps_revision(self):
+        before = self._revision()
+        StopTime.objects.filter(trip=self.trip).first().delete()
+        self.assertGreater(self._revision(), before)
+
+    def test_version_changes_with_revision(self):
+        with for_island(self.island):
+            v1 = compute_bundle_version(self.island)
+        bump_data_revision(self.island.id)
+        self.island.refresh_from_db()
+        with for_island(self.island):
+            v2 = compute_bundle_version(self.island)
+        self.assertNotEqual(v1, v2)
+
+    def test_suppress_revision_bumps(self):
+        before = self._revision()
+        with suppress_revision_bumps():
+            Stop.objects.create(
+                island=self.island,
+                name='Vila Franca',
+                cleaned_name='vila franca',
+                latitude=37.71,
+                longitude=-25.43,
+            )
+        self.assertEqual(self._revision(), before)

--- a/src/transit/throttling.py
+++ b/src/transit/throttling.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from rest_framework.throttling import SimpleRateThrottle
 
 
-class DirectionsSessionThrottle(SimpleRateThrottle):
-    """Rate-limit directions by pseudonymous session (falls back to client IP)."""
-
-    scope = 'directions'
+class _SessionScopedThrottle(SimpleRateThrottle):
+    """Rate-limit by pseudonymous session (falls back to client IP), scoped per island."""
 
     def get_cache_key(self, request, view):
         session_id = (
@@ -19,3 +17,13 @@ class DirectionsSessionThrottle(SimpleRateThrottle):
         island_key = island.key if island else 'unknown'
         ident = session_id or self.get_ident(request)
         return self.cache_format % {'scope': self.scope, 'ident': f'{island_key}:{ident}'}
+
+
+class DirectionsSessionThrottle(_SessionScopedThrottle):
+    scope = 'directions'
+
+
+class OfflineBundleThrottle(_SessionScopedThrottle):
+    """Rate-limit offline-bundle downloads (large payload) per session/IP."""
+
+    scope = 'offline-bundle'

--- a/src/transit/urls_v3.py
+++ b/src/transit/urls_v3.py
@@ -3,6 +3,8 @@ from django.urls import path
 from transit.api_v3 import (
     transit_directions_view,
     transit_line_detail_view,
+    transit_offline_bundle_view,
+    transit_offline_version_view,
     transit_search_view,
     transit_stops_view,
     transit_trip_detail_view,
@@ -11,6 +13,8 @@ from transit.api_v3 import (
 
 urlpatterns = [
     path('stops', transit_stops_view, name='v3-transit-stops'),
+    path('offline-bundle', transit_offline_bundle_view, name='v3-transit-offline-bundle'),
+    path('offline-bundle/version', transit_offline_version_view, name='v3-transit-offline-version'),
     path('search', transit_search_view, name='v3-transit-search'),
     path('directions', transit_directions_view, name='v3-transit-directions'),
     path('trips/<int:trip_id>', transit_trip_detail_view, name='v3-transit-trip-detail'),


### PR DESCRIPTION
## Summary
Adds a versioned offline transit data bundle so the mobile client can search routes offline (premium-gated on the client side).

- **`data_revision` staleness signal** — write-triggered integer bumped via `post_save`/`post_delete` on all schedule-bearing transit models (`Stop`, `Line`, `Trip`, `StopTime`, `Calendar`, `Holiday`, `RouteInfo`). Vote-only `Trip` saves (likes/dislikes) are excluded. Bulk legacy import suppresses per-row bumps and fires a single bump + cache prewarm at the end.
- **`build_offline_bundle` + `compute_bundle_version`** — serializes stops/routes/schedules/holidays/infos into one payload with a version fingerprint.
- **`GET /api/v3/transit/offline-bundle`** — full bundle, Redis-cached keyed by version, single-flight lock against stampedes, ETag + `If-None-Match` conditional GET (304), throttled at `offline-bundle: 12/min`.
- **`GET /api/v3/transit/offline-bundle/version`** — lightweight staleness check the client polls before downloading.

## Test plan
- [x] `pytest transit/ tenancy/` — 43 passing
- [x] 11 new tests: bundle structure, revision bumps (and vote exclusion), version changes, suppression, `/version` + `/offline-bundle` endpoints, ETag/304, version change after edits
- [x] Also fixed a pre-existing flaky directions cache test (no `cache.clear()` in `setUp`)

Made with [Cursor](https://cursor.com)