### PR TITLE
feat(weather): parish hourly forecast endpoint

### DIFF
--- a/src/weather/api_v3.py
+++ b/src/weather/api_v3.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from tenancy.services import for_island
 from weather.models import Parish
 from weather.open_meteo_client import OpenMeteoError
-from weather.services import ATTRIBUTION, get_parish_weather, list_parish_weather
+from weather.services import ATTRIBUTION, get_parish_hourly, get_parish_weather, list_parish_weather
 
 
 def _require_island(request: Request) -> Response | None:
@@ -59,6 +59,44 @@ def parish_detail_view(request: Request, slug: str) -> Response:
 
         try:
             payload = get_parish_weather(parish)
+        except OpenMeteoError as exc:
+            return Response(
+                {'error': {'code': 'weather_unavailable', 'message': str(exc)}},
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+    return Response(payload)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def parish_hourly_view(request: Request, slug: str) -> Response:
+    err = _require_island(request)
+    if err:
+        return err
+
+    date_str = request.query_params.get('date')
+    if not date_str:
+        return Response(
+            {'error': {'code': 'invalid_date', 'message': 'Query parameter date is required (YYYY-MM-DD)'}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    with for_island(request.island):
+        parish = Parish.objects.filter(island=request.island, slug=slug, is_active=True).first()
+        if parish is None:
+            return Response(
+                {'error': {'code': 'not_found', 'message': 'Parish not found'}},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            payload = get_parish_hourly(parish, date_str)
+        except ValueError as exc:
+            return Response(
+                {'error': {'code': 'invalid_date', 'message': str(exc)}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except OpenMeteoError as exc:
             return Response(
                 {'error': {'code': 'weather_unavailable', 'message': str(exc)}},

--- a/src/weather/open_meteo_client.py
+++ b/src/weather/open_meteo_client.py
@@ -20,6 +20,10 @@ CURRENT_VARS = (
 DAILY_VARS = (
     'weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max'
 )
+HOURLY_VARS = (
+    'temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m,'
+    'precipitation,precipitation_probability'
+)
 
 
 class OpenMeteoError(Exception):
@@ -71,3 +75,39 @@ def fetch_forecast(coords: list[Coord]) -> list[dict[str, Any]]:
             )
         return payload
     raise OpenMeteoError('Unexpected Open-Meteo multi-location response shape')
+
+
+def fetch_hourly(coord: Coord, *, forecast_days: int) -> dict[str, Any]:
+    """Fetch hourly forecast for a single coordinate."""
+    if forecast_days < 1 or forecast_days > 3:
+        raise ValueError('forecast_days must be between 1 and 3')
+
+    params = {
+        'latitude': str(coord.latitude),
+        'longitude': str(coord.longitude),
+        'hourly': HOURLY_VARS,
+        'timezone': 'auto',
+        'forecast_days': str(forecast_days),
+    }
+    url = f'{OPEN_METEO_BASE_URL}/forecast'
+
+    try:
+        response = requests.get(url, params=params, timeout=OPEN_METEO_TIMEOUT)
+    except requests.RequestException as exc:
+        logger.exception('Open-Meteo hourly request failed')
+        raise OpenMeteoError(str(exc)) from exc
+
+    if not response.ok:
+        logger.warning('Open-Meteo hourly HTTP %s: %s', response.status_code, response.text[:500])
+        raise OpenMeteoError(f'Open-Meteo HTTP {response.status_code}')
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise OpenMeteoError('Invalid JSON from Open-Meteo') from exc
+
+    hourly = payload.get('hourly')
+    if not hourly or not hourly.get('time'):
+        raise OpenMeteoError('Missing hourly data from Open-Meteo')
+
+    return payload

--- a/src/weather/services.py
+++ b/src/weather/services.py
@@ -3,22 +3,29 @@
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import Any
 
 from django.core.cache import cache
 
 from tenancy.models import Island
 from weather.models import Parish
-from weather.open_meteo_client import Coord, OpenMeteoError, fetch_forecast
+from weather.open_meteo_client import Coord, OpenMeteoError, fetch_forecast, fetch_hourly
 
 logger = logging.getLogger(__name__)
 
 CACHE_TTL = 3600
+HOURLY_TTL_TODAY = 3600
+HOURLY_TTL_FUTURE = 86400
 ATTRIBUTION = 'Weather data by Open-Meteo.com (CC BY 4.0)'
 
 
 def _cache_key(island_key: str, slug: str) -> str:
     return f'weather:parish:{island_key}:{slug}'
+
+
+def _hourly_cache_key(island_key: str, slug: str, date_str: str) -> str:
+    return f'weather:parish:{island_key}:{slug}:hourly:{date_str}'
 
 
 def _serialize_daily(daily: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -137,3 +144,88 @@ def list_parish_weather(island: Island) -> list[dict[str, Any]]:
 
     results.sort(key=lambda row: (row.get('concelho', ''), row.get('name', '')))
     return results
+
+
+def _allowed_forecast_dates(parish_weather: dict[str, Any]) -> set[str]:
+    daily = parish_weather.get('daily') or []
+    return {row['date'] for row in daily if row.get('date')}
+
+
+def _parish_local_today(parish_weather: dict[str, Any]) -> date:
+    current_time = (parish_weather.get('current') or {}).get('time')
+    if current_time:
+        return date.fromisoformat(str(current_time).split('T')[0])
+    daily = parish_weather.get('daily') or []
+    if daily and daily[0].get('date'):
+        return date.fromisoformat(daily[0]['date'])
+    return date.today()
+
+
+def _forecast_days_for_date(local_today: date, target: date) -> int:
+    delta = (target - local_today).days
+    return min(3, max(1, delta + 1))
+
+
+def _serialize_hourly_slots(hourly: dict[str, Any], target_date: str) -> list[dict[str, Any]]:
+    times = hourly.get('time') or []
+    temps = hourly.get('temperature_2m') or []
+    codes = hourly.get('weather_code') or []
+    winds = hourly.get('wind_speed_10m') or []
+    humidities = hourly.get('relative_humidity_2m') or []
+    precips = hourly.get('precipitation') or []
+    precip_probs = hourly.get('precipitation_probability') or []
+    out: list[dict[str, Any]] = []
+    for i, time_str in enumerate(times):
+        if str(time_str).split('T')[0] != target_date:
+            continue
+        out.append({
+            'time': time_str,
+            'temperature': temps[i] if i < len(temps) else None,
+            'weatherCode': codes[i] if i < len(codes) else None,
+            'windSpeed': winds[i] if i < len(winds) else None,
+            'humidity': humidities[i] if i < len(humidities) else None,
+            'precipitation': precips[i] if i < len(precips) else None,
+            'precipitationProbability': precip_probs[i] if i < len(precip_probs) else None,
+        })
+    return out
+
+
+def get_parish_hourly(parish: Parish, date_str: str) -> dict[str, Any]:
+    """Return hourly slots for one parish on a date within the 3-day forecast window."""
+    try:
+        target_date = date.fromisoformat(date_str)
+    except ValueError as exc:
+        raise ValueError('Invalid date format; use YYYY-MM-DD') from exc
+
+    parish_weather = get_parish_weather(parish)
+    allowed = _allowed_forecast_dates(parish_weather)
+    if date_str not in allowed:
+        raise ValueError(f'Date {date_str} is outside the forecast window')
+
+    island_key = parish.island.key
+    cache_key = _hourly_cache_key(island_key, parish.slug, date_str)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    local_today = _parish_local_today(parish_weather)
+    forecast_days = _forecast_days_for_date(local_today, target_date)
+    raw = fetch_hourly(
+        Coord(parish.latitude, parish.longitude),
+        forecast_days=forecast_days,
+    )
+    hourly = raw.get('hourly')
+    if not hourly:
+        raise OpenMeteoError('Missing hourly data from Open-Meteo')
+
+    hours = _serialize_hourly_slots(hourly, date_str)
+    payload = {
+        'slug': parish.slug,
+        'date': date_str,
+        'hours': hours,
+        'attribution': ATTRIBUTION,
+    }
+
+    ttl = HOURLY_TTL_TODAY if target_date == local_today else HOURLY_TTL_FUTURE
+    cache.set(cache_key, payload, ttl)
+    return payload

--- a/src/weather/tests/test_weather.py
+++ b/src/weather/tests/test_weather.py
@@ -12,6 +12,18 @@ from weather.models import Parish
 from weather.open_meteo_client import Coord, OpenMeteoError
 from weather.services import ATTRIBUTION, refresh_parishes, serialize_parish_weather
 
+SAMPLE_HOURLY_RAW = {
+    'hourly': {
+        'time': [f'2026-06-03T{h:02d}:00' for h in range(24)],
+        'temperature_2m': [18.0 + (h % 5) for h in range(24)],
+        'weather_code': [1] * 24,
+        'wind_speed_10m': [12.0] * 24,
+        'relative_humidity_2m': [70] * 24,
+        'precipitation': [0.0] * 24,
+        'precipitation_probability': [15] * 24,
+    },
+}
+
 SAMPLE_RAW = {
     'current': {
         'time': '2026-06-03T12:00',
@@ -87,9 +99,48 @@ class OpenMeteoClientTestCase(TestCase):
         with self.assertRaises(OpenMeteoError):
             fetch_forecast([Coord(37.74, -25.67)])
 
+    @patch('weather.open_meteo_client.requests.get')
+    def test_fetch_hourly_builds_params(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = SAMPLE_HOURLY_RAW
+
+        from weather.open_meteo_client import fetch_hourly
+
+        result = fetch_hourly(Coord(37.74, -25.67), forecast_days=2)
+        self.assertIn('hourly', result)
+        params = mock_get.call_args.kwargs['params']
+        self.assertEqual(params['latitude'], '37.74')
+        self.assertEqual(params['longitude'], '-25.67')
+        self.assertEqual(params['forecast_days'], '2')
+        self.assertIn('temperature_2m', params['hourly'])
+
+    @patch('weather.open_meteo_client.requests.get')
+    def test_fetch_hourly_http_error(self, mock_get):
+        mock_get.return_value.ok = False
+        mock_get.return_value.status_code = 503
+        mock_get.return_value.text = 'unavailable'
+
+        from weather.open_meteo_client import fetch_hourly
+
+        with self.assertRaises(OpenMeteoError):
+            fetch_hourly(Coord(37.74, -25.67), forecast_days=1)
+
+    @patch('weather.open_meteo_client.requests.get')
+    def test_fetch_hourly_malformed_payload(self, mock_get):
+        mock_get.return_value.ok = True
+        mock_get.return_value.json.return_value = {'hourly': {'time': []}}
+
+        from weather.open_meteo_client import fetch_hourly
+
+        with self.assertRaises(OpenMeteoError):
+            fetch_hourly(Coord(37.74, -25.67), forecast_days=1)
+
 
 class WeatherServicesTestCase(TestCase):
     def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
         self.island = get_or_create_default_island()
         self.parish = Parish.objects.create(
             island=self.island,
@@ -146,6 +197,116 @@ class WeatherServicesTestCase(TestCase):
     def test_refresh_empty_parishes(self, _mock_fetch):
         self.assertEqual(refresh_parishes([]), 0)
 
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        },
+    )
+    @patch('weather.services.fetch_hourly', return_value=SAMPLE_HOURLY_RAW)
+    @patch('weather.services.fetch_forecast', return_value=[SAMPLE_RAW])
+    def test_get_parish_hourly_returns_slots(self, _mock_forecast, mock_hourly):
+        from weather.services import get_parish_hourly
+
+        refresh_parishes([self.parish])
+        payload = get_parish_hourly(self.parish, '2026-06-03')
+        self.assertEqual(payload['slug'], self.parish.slug)
+        self.assertEqual(payload['date'], '2026-06-03')
+        self.assertEqual(len(payload['hours']), 24)
+        slot = payload['hours'][0]
+        self.assertEqual(slot['time'], '2026-06-03T00:00')
+        self.assertIn('temperature', slot)
+        self.assertIn('weatherCode', slot)
+        self.assertIn('precipitationProbability', slot)
+        mock_hourly.assert_called_once()
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        },
+    )
+    @patch('weather.services.fetch_hourly', return_value=SAMPLE_HOURLY_RAW)
+    @patch('weather.services.fetch_forecast', return_value=[SAMPLE_RAW])
+    def test_get_parish_hourly_cache_hit(self, _mock_forecast, mock_hourly):
+        from weather.services import get_parish_hourly
+
+        refresh_parishes([self.parish])
+        get_parish_hourly(self.parish, '2026-06-03')
+        get_parish_hourly(self.parish, '2026-06-03')
+        self.assertEqual(mock_hourly.call_count, 1)
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        },
+    )
+    @patch('weather.services.fetch_forecast', return_value=[SAMPLE_RAW])
+    def test_get_parish_hourly_invalid_date(self, _mock_forecast):
+        from weather.services import get_parish_hourly
+
+        refresh_parishes([self.parish])
+        with self.assertRaises(ValueError):
+            get_parish_hourly(self.parish, '2026-06-10')
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        },
+    )
+    @patch('weather.services.fetch_hourly', return_value=SAMPLE_HOURLY_RAW)
+    def test_get_parish_hourly_future_ttl(self, _mock_hourly):
+        from django.core.cache import cache
+
+        from weather.services import (
+            HOURLY_TTL_FUTURE,
+            _cache_key,
+            get_parish_hourly,
+        )
+
+        cache.set(
+            _cache_key(self.island.key, self.parish.slug),
+            serialize_parish_weather(self.parish, SAMPLE_RAW),
+            3600,
+        )
+        with patch.object(cache, 'set', wraps=cache.set) as mock_set:
+            get_parish_hourly(self.parish, '2026-06-04')
+            hourly_calls = [c for c in mock_set.call_args_list if ':hourly:' in c[0][0]]
+        self.assertEqual(hourly_calls[0][0][2], HOURLY_TTL_FUTURE)
+
+    @override_settings(
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            }
+        },
+    )
+    @patch('weather.services.fetch_hourly', return_value=SAMPLE_HOURLY_RAW)
+    def test_get_parish_hourly_today_ttl(self, _mock_hourly):
+        from django.core.cache import cache
+
+        from weather.services import (
+            HOURLY_TTL_TODAY,
+            _cache_key,
+            get_parish_hourly,
+        )
+
+        cache.set(
+            _cache_key(self.island.key, self.parish.slug),
+            serialize_parish_weather(self.parish, SAMPLE_RAW),
+            3600,
+        )
+        with patch.object(cache, 'set', wraps=cache.set) as mock_set:
+            get_parish_hourly(self.parish, '2026-06-03')
+            hourly_calls = [c for c in mock_set.call_args_list if ':hourly:' in c[0][0]]
+        self.assertEqual(hourly_calls[0][0][2], HOURLY_TTL_TODAY)
+
 
 class WeatherAPITestCase(TestCase):
     def setUp(self):
@@ -198,3 +359,42 @@ class WeatherAPITestCase(TestCase):
         response = self.client.get('/api/v3/weather/parishes', **self.headers)
         self.assertEqual(response.status_code, 502)
         self.assertEqual(response.json()['error']['code'], 'weather_unavailable')
+
+    @patch('weather.api_v3.get_parish_hourly')
+    def test_parish_hourly(self, mock_hourly):
+        mock_hourly.return_value = {
+            'slug': self.parish.slug,
+            'date': '2026-06-03',
+            'hours': [{'time': '2026-06-03T12:00', 'temperature': 18, 'weatherCode': 1}],
+            'attribution': ATTRIBUTION,
+        }
+        response = self.client.get(
+            f'/api/v3/weather/parishes/{self.parish.slug}/hourly?date=2026-06-03',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['date'], '2026-06-03')
+        self.assertEqual(len(body['hours']), 1)
+
+    def test_parish_hourly_missing_date(self):
+        response = self.client.get(
+            f'/api/v3/weather/parishes/{self.parish.slug}/hourly',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    @patch('weather.api_v3.get_parish_hourly', side_effect=ValueError('outside window'))
+    def test_parish_hourly_invalid_date(self, _mock):
+        response = self.client.get(
+            f'/api/v3/weather/parishes/{self.parish.slug}/hourly?date=2026-06-10',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_parish_hourly_not_found(self):
+        response = self.client.get(
+            '/api/v3/weather/parishes/unknown-slug/hourly?date=2026-06-03',
+            **self.headers,
+        )
+        self.assertEqual(response.status_code, 404)

--- a/src/weather/urls_v3.py
+++ b/src/weather/urls_v3.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from weather.api_v3 import parish_detail_view, parishes_list_view
+from weather.api_v3 import parish_detail_view, parish_hourly_view, parishes_list_view
 
 urlpatterns = [
     path('parishes', parishes_list_view, name='v3-weather-parishes'),
+    path('parishes/<slug:slug>/hourly', parish_hourly_view, name='v3-weather-parish-hourly'),
     path('parishes/<slug:slug>', parish_detail_view, name='v3-weather-parish-detail'),
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds on-demand hourly weather for parish detail without changing existing list/detail payloads or the Celery island-wide refresh.

- New `GET /api/v3/weather/parishes/{slug}/hourly?date=YYYY-MM-DD`
- Lazy Open-Meteo `fetch_hourly` on cache miss; per `(island, slug, date)` Redis TTL (1h today, 24h future)
- Date validated against the cached 3-day daily window
- Hourly fields: `time`, `temperature`, `weatherCode`, `windSpeed`, `humidity`, `precipitation`, `precipitationProbability`

## Test plan

- [x] `cd src && pytest weather/tests/test_weather.py` — 24 passed
- [ ] Manual: `GET .../hourly?date=<today>` returns slots; out-of-range date → 400
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ef6c290-4992-43d5-b0cc-5c8e59ee67a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ef6c290-4992-43d5-b0cc-5c8e59ee67a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

