### PR TITLE
feat(analytics): reporting API + static stats dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,24 @@ Docker Compose host mappings: `WEB_PORT`, `WEB_CONTAINER_PORT`, `DB_PORT_EXPOSE`
 - Celery beat: `weather.refresh_forecasts` hourly warms cache for all active parishes (one batched upstream call per island).
 - Bootstrap module key: `weather` (`tenancy` migration `0011_enable_weather_feature_flag`).
 
+### Analytics reporting + stats dashboard (`analytics` app — shipped)
+
+Read-side, **AUTH_KEY-protected** endpoints (via `X-Auth-Key` header or `?key=`) that aggregate stored analytics. v3 endpoints are tenant-scoped (`X-Island`); legacy ones are global.
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /api/v3/analytics/reports/overview` | v3 `AnalyticsEvent`: totals, time series, breakdowns (module, event_type, platform, locale) |
+| `GET /api/v3/analytics/reports/events` | v3 raw events — paginated + filterable |
+| `GET /api/v3/analytics/reports/meta` | v3 distinct filter values + date bounds |
+| `GET /api/v3/analytics/reports/legacy/overview` | legacy `Stat`: totals, series, breakdowns (request, top routes/origins/destinations, platform, language, day type) |
+| `GET /api/v3/analytics/reports/legacy/events` | legacy raw stats — paginated |
+| `GET /api/v3/analytics/reports/legacy/meta` | legacy distinct filter values |
+
+- Params: `start`, `end` (`YYYY-MM-DD`), `interval` (`hour\|day\|month`, auto by range), `page`, `page_size`, plus per-source filters (`module`, `event_type`, `platform`, `locale` / `request`, `language`).
+- Logic: `analytics/services_reporting.py`; views: `analytics/api_reporting.py`.
+- `CORS_ALLOW_HEADERS` allows `x-auth-key` / `x-api-key` so the static dashboard can call cross-origin.
+- **Dashboard:** `docs/` — zero-build umami-style HTML/CSS/JS for GitHub Pages (Settings → Pages → `/docs`). Tabs for Hub (v3) / Legacy, date-range presets, time-series chart, breakdowns, paginated table. Connection config (API base, AUTH key, island) lives in browser `localStorage`. See `docs/README.md`.
+
 ### Legacy data import
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,63 @@
+# São Miguel Hub — Analytics Dashboard
+
+A zero-build, static (HTML/CSS/JS) analytics dashboard — umami-style — for the
+São Miguel Hub backend. It reads aggregated stats from the AUTH_KEY-protected
+reporting API and renders them entirely in the browser. No data is stored
+server-side by the dashboard; the AUTH key lives only in the visitor's
+`localStorage`.
+
+## What it shows
+
+Two data sources, switchable from the top tabs:
+
+- **Hub (v3)** — the first-party `AnalyticsEvent` stream (`/api/v3/analytics/reports/*`).
+  Metrics: events, sessions. Breakdowns: modules, event types, platforms, locales.
+- **Legacy** — the legacy `Stat` table (`/api/v3/analytics/reports/legacy/*`).
+  Metrics: requests, route searches. Breakdowns: request types, top routes /
+  origins / destinations, platforms, languages, day type.
+
+Each source has date-range presets (24h → 1y) + custom range, a time-series
+chart, breakdown panels, and a paginated raw-events table with filters.
+
+## Backing API
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /api/v3/analytics/reports/overview` | v3 totals, time series, breakdowns |
+| `GET /api/v3/analytics/reports/events` | v3 raw events (paginated, filterable) |
+| `GET /api/v3/analytics/reports/meta` | v3 distinct filter values + bounds |
+| `GET /api/v3/analytics/reports/legacy/overview` | legacy totals, series, breakdowns |
+| `GET /api/v3/analytics/reports/legacy/events` | legacy raw stats (paginated) |
+| `GET /api/v3/analytics/reports/legacy/meta` | legacy distinct filter values |
+
+All require the `AUTH_KEY` via the `X-Auth-Key` header (or `?key=`). The v3
+endpoints are tenant-scoped via the `X-Island` header.
+
+Common query params: `start`, `end` (`YYYY-MM-DD`), `interval`
+(`hour|day|month`), `page`, `page_size`, plus the per-source filters
+(`module`, `event_type`, `platform`, `locale` / `request`, `language`).
+
+## Configuration
+
+Open **⚙ Settings** in the dashboard and set:
+
+- **API base URL** — e.g. `https://api.saomiguelbus.com` (default).
+- **AUTH key** — the backend `AUTH_KEY`.
+- **Island key** — tenant slug, default `sao-miguel`.
+
+## Local preview
+
+```bash
+cd docs
+python3 -m http.server 4000
+# open http://localhost:4000
+```
+
+## Deploy to GitHub Pages
+
+GitHub repo → **Settings → Pages** → *Deploy from a branch* → select the branch
+and the `/docs` folder. The `.nojekyll` file disables Jekyll processing. The
+dashboard is fully client-side, so no build pipeline is required.
+
+> Cross-origin requests work because the API sets `CORS_ALLOW_ALL_ORIGINS` and
+> allows the `X-Auth-Key` / `X-Island` headers.

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,0 +1,437 @@
+/* São Miguel Hub — static analytics dashboard.
+ * Talks to the AUTH_KEY-protected /api/v3/analytics/reports/* endpoints.
+ * No build step: plain ES2015+ for GitHub Pages. */
+(function () {
+  'use strict';
+
+  var CONFIG_KEY = 'smb_analytics_config';
+  var DEFAULTS = { apiBase: 'https://api.saomiguelbus.com', authKey: '', island: 'sao-miguel' };
+
+  var SOURCES = {
+    v3: {
+      label: 'Hub (v3)',
+      overview: '/api/v3/analytics/reports/overview',
+      events: '/api/v3/analytics/reports/events',
+      meta: '/api/v3/analytics/reports/meta',
+      needsIsland: true,
+      metrics: [
+        { key: 'events', label: 'Events' },
+        { key: 'sessions', label: 'Sessions' }
+      ],
+      series: [
+        { key: 'events', label: 'Events', color: '#218732' },
+        { key: 'sessions', label: 'Sessions', color: '#ffc107' }
+      ],
+      breakdowns: [
+        { key: 'module', title: 'Modules' },
+        { key: 'event_type', title: 'Event types' },
+        { key: 'platform', title: 'Platforms' },
+        { key: 'locale', title: 'Locales' }
+      ],
+      filters: [
+        { param: 'module', metaKey: 'modules', label: 'Module' },
+        { param: 'event_type', metaKey: 'event_types', label: 'Event type' },
+        { param: 'platform', metaKey: 'platforms', label: 'Platform' }
+      ],
+      columns: [
+        { key: 'occurred_at', label: 'Time', time: true },
+        { key: 'module', label: 'Module' },
+        { key: 'event_type', label: 'Event' },
+        { key: 'platform', label: 'Platform' },
+        { key: 'locale', label: 'Locale' },
+        { key: 'properties', label: 'Properties', json: true }
+      ]
+    },
+    legacy: {
+      label: 'Legacy',
+      overview: '/api/v3/analytics/reports/legacy/overview',
+      events: '/api/v3/analytics/reports/legacy/events',
+      meta: '/api/v3/analytics/reports/legacy/meta',
+      needsIsland: false,
+      metrics: [
+        { key: 'stats', label: 'Requests' },
+        { key: 'routes', label: 'Route searches' }
+      ],
+      series: [{ key: 'count', label: 'Requests', color: '#218732' }],
+      breakdowns: [
+        { key: 'request', title: 'Request types' },
+        { key: 'top_routes', title: 'Top routes' },
+        { key: 'top_origins', title: 'Top origins' },
+        { key: 'top_destinations', title: 'Top destinations' },
+        { key: 'platform', title: 'Platforms' },
+        { key: 'language', title: 'Languages' },
+        { key: 'type_of_day', title: 'Day type' }
+      ],
+      filters: [
+        { param: 'request', metaKey: 'requests', label: 'Request' },
+        { param: 'platform', metaKey: 'platforms', label: 'Platform' },
+        { param: 'language', metaKey: 'languages', label: 'Language' }
+      ],
+      columns: [
+        { key: 'timestamp', label: 'Time', time: true },
+        { key: 'request', label: 'Request' },
+        { key: 'origin', label: 'Origin' },
+        { key: 'destination', label: 'Destination' },
+        { key: 'platform', label: 'Platform' },
+        { key: 'language', label: 'Lang' },
+        { key: 'type_of_day', label: 'Day' }
+      ]
+    }
+  };
+
+  var state = {
+    config: loadConfig(),
+    source: 'v3',
+    rangeDays: 7,
+    start: null,
+    end: null,
+    filters: {},
+    page: 1,
+    pageSize: 50,
+    meta: {}
+  };
+
+  var els = {};
+  var chart = null;
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    cache();
+    bind();
+    syncRangeInputs();
+    els.footerApi.textContent = state.config.apiBase;
+    if (!state.config.authKey) {
+      openSettings();
+    }
+    refresh();
+  }
+
+  function cache() {
+    els.tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+    els.rangePresets = document.getElementById('rangePresets');
+    els.startDate = document.getElementById('startDate');
+    els.endDate = document.getElementById('endDate');
+    els.filterBar = document.getElementById('filterBar');
+    els.refreshBtn = document.getElementById('refreshBtn');
+    els.metricCards = document.getElementById('metricCards');
+    els.seriesTitle = document.getElementById('seriesTitle');
+    els.seriesInterval = document.getElementById('seriesInterval');
+    els.seriesChart = document.getElementById('seriesChart');
+    els.breakdownGrid = document.getElementById('breakdownGrid');
+    els.eventsTable = document.getElementById('eventsTable');
+    els.pageLabel = document.getElementById('pageLabel');
+    els.prevPage = document.getElementById('prevPage');
+    els.nextPage = document.getElementById('nextPage');
+    els.errorBanner = document.getElementById('errorBanner');
+    els.connectionDot = document.getElementById('connectionDot');
+    els.footerApi = document.getElementById('footerApi');
+    // Settings
+    els.settingsBtn = document.getElementById('settingsBtn');
+    els.settingsModal = document.getElementById('settingsModal');
+    els.settingsClose = document.getElementById('settingsClose');
+    els.settingsSave = document.getElementById('settingsSave');
+    els.apiBase = document.getElementById('apiBase');
+    els.authKey = document.getElementById('authKey');
+    els.islandKey = document.getElementById('islandKey');
+  }
+
+  function bind() {
+    els.tabs.forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        if (tab.classList.contains('is-active')) return;
+        els.tabs.forEach(function (t) { t.classList.remove('is-active'); });
+        tab.classList.add('is-active');
+        state.source = tab.getAttribute('data-source');
+        state.filters = {};
+        state.page = 1;
+        refresh();
+      });
+    });
+
+    els.rangePresets.addEventListener('click', function (e) {
+      var btn = e.target.closest('.chip');
+      if (!btn) return;
+      Array.prototype.forEach.call(els.rangePresets.children, function (c) { c.classList.remove('is-active'); });
+      btn.classList.add('is-active');
+      state.rangeDays = parseInt(btn.getAttribute('data-range'), 10);
+      state.start = null;
+      state.end = null;
+      state.page = 1;
+      syncRangeInputs();
+      refresh();
+    });
+
+    function onDateChange() {
+      state.start = els.startDate.value || null;
+      state.end = els.endDate.value || null;
+      if (state.start || state.end) {
+        Array.prototype.forEach.call(els.rangePresets.children, function (c) { c.classList.remove('is-active'); });
+      }
+      state.page = 1;
+      refresh();
+    }
+    els.startDate.addEventListener('change', onDateChange);
+    els.endDate.addEventListener('change', onDateChange);
+
+    els.refreshBtn.addEventListener('click', refresh);
+    els.prevPage.addEventListener('click', function () { if (state.page > 1) { state.page--; loadEvents(); } });
+    els.nextPage.addEventListener('click', function () { state.page++; loadEvents(); });
+
+    els.settingsBtn.addEventListener('click', openSettings);
+    els.settingsClose.addEventListener('click', closeSettings);
+    els.settingsSave.addEventListener('click', saveSettings);
+    els.settingsModal.addEventListener('click', function (e) {
+      if (e.target === els.settingsModal) closeSettings();
+    });
+  }
+
+  /* --- config --- */
+  function loadConfig() {
+    var cfg = {};
+    try { cfg = JSON.parse(localStorage.getItem(CONFIG_KEY)) || {}; } catch (e) { cfg = {}; }
+    return {
+      apiBase: (cfg.apiBase || DEFAULTS.apiBase).replace(/\/+$/, ''),
+      authKey: cfg.authKey || DEFAULTS.authKey,
+      island: cfg.island || DEFAULTS.island
+    };
+  }
+
+  function openSettings() {
+    els.apiBase.value = state.config.apiBase;
+    els.authKey.value = state.config.authKey;
+    els.islandKey.value = state.config.island;
+    els.settingsModal.hidden = false;
+  }
+  function closeSettings() { els.settingsModal.hidden = true; }
+  function saveSettings() {
+    state.config = {
+      apiBase: (els.apiBase.value || DEFAULTS.apiBase).replace(/\/+$/, ''),
+      authKey: els.authKey.value || '',
+      island: els.islandKey.value || DEFAULTS.island
+    };
+    localStorage.setItem(CONFIG_KEY, JSON.stringify(state.config));
+    els.footerApi.textContent = state.config.apiBase;
+    closeSettings();
+    refresh();
+  }
+
+  /* --- range helpers --- */
+  function syncRangeInputs() {
+    var range = computeRange();
+    els.startDate.value = range.start;
+    els.endDate.value = range.end;
+  }
+  function computeRange() {
+    if (state.start || state.end) {
+      var endC = state.end || isoDate(new Date());
+      var startC = state.start || endC;
+      return { start: startC, end: endC };
+    }
+    var end = new Date();
+    var start = new Date();
+    start.setDate(end.getDate() - (state.rangeDays - 1));
+    return { start: isoDate(start), end: isoDate(end) };
+  }
+  function isoDate(d) {
+    return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+  }
+  function pad(n) { return (n < 10 ? '0' : '') + n; }
+
+  /* --- API --- */
+  function api(path, params) {
+    var cfg = state.config;
+    var url = cfg.apiBase + path;
+    var qs = [];
+    Object.keys(params || {}).forEach(function (k) {
+      if (params[k] !== null && params[k] !== undefined && params[k] !== '') {
+        qs.push(encodeURIComponent(k) + '=' + encodeURIComponent(params[k]));
+      }
+    });
+    if (qs.length) url += '?' + qs.join('&');
+    var headers = { 'X-Auth-Key': cfg.authKey };
+    if (SOURCES[state.source].needsIsland) headers['X-Island'] = cfg.island;
+    return fetch(url, { headers: headers }).then(function (res) {
+      if (res.status === 401) throw new Error('Unauthorized — check the AUTH key in Settings.');
+      if (!res.ok) throw new Error('API error ' + res.status);
+      return res.json();
+    });
+  }
+
+  function commonParams() {
+    var range = computeRange();
+    var params = { start: range.start, end: range.end };
+    Object.keys(state.filters).forEach(function (k) {
+      if (state.filters[k]) params[k] = state.filters[k];
+    });
+    return params;
+  }
+
+  /* --- orchestration --- */
+  function refresh() {
+    var src = SOURCES[state.source];
+    setError('');
+    loadMeta(src);
+    Promise.all([
+      api(src.overview, commonParams()),
+      loadEvents()
+    ]).then(function (results) {
+      setConn('ok');
+      renderOverview(src, results[0]);
+    }).catch(function (err) {
+      setConn('err');
+      setError(err.message || String(err));
+    });
+  }
+
+  function loadMeta(src) {
+    api(src.meta, SOURCES[state.source].needsIsland ? {} : {}).then(function (meta) {
+      state.meta = meta;
+      renderFilters(src, meta);
+    }).catch(function () { /* filters are optional */ });
+  }
+
+  function loadEvents() {
+    var src = SOURCES[state.source];
+    var params = commonParams();
+    params.page = state.page;
+    params.page_size = state.pageSize;
+    return api(src.events, params).then(function (data) {
+      renderTable(src, data);
+      return data;
+    });
+  }
+
+  /* --- rendering --- */
+  function renderOverview(src, data) {
+    var totals = data.totals || {};
+    els.metricCards.innerHTML = src.metrics.map(function (m) {
+      return '<div class="metric"><div class="metric__label">' + esc(m.label) +
+        '</div><div class="metric__value">' + fmt(totals[m.key] || 0) + '</div></div>';
+    }).join('') + extraMetric(src, data);
+
+    renderSeries(src, data);
+    renderBreakdowns(src, data.breakdowns || {});
+    els.seriesInterval.textContent = data.range ? ('per ' + data.range.interval) : '';
+  }
+
+  function extraMetric(src, data) {
+    var n = (data.series || []).length;
+    if (!n) return '';
+    var primary = src.metrics[0].key;
+    var total = (data.totals && data.totals[primary]) || 0;
+    var avg = Math.round(total / n);
+    return '<div class="metric"><div class="metric__label">Avg / ' +
+      (data.range ? data.range.interval : 'bucket') + '</div><div class="metric__value">' +
+      fmt(avg) + '</div></div>';
+  }
+
+  function renderSeries(src, data) {
+    var series = data.series || [];
+    var interval = data.range ? data.range.interval : 'day';
+    var labels = series.map(function (row) { return labelFor(row.bucket, interval); });
+    var datasets = src.series.map(function (s) {
+      return {
+        label: s.label,
+        data: series.map(function (row) { return row[s.key] || 0; }),
+        backgroundColor: s.color,
+        borderRadius: 4,
+        maxBarThickness: 36
+      };
+    });
+    if (chart) chart.destroy();
+    chart = new Chart(els.seriesChart.getContext('2d'), {
+      type: 'bar',
+      data: { labels: labels, datasets: datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: datasets.length > 1, position: 'bottom' } },
+        scales: {
+          x: { grid: { display: false } },
+          y: { beginAtZero: true, ticks: { precision: 0 }, grid: { color: '#eef0f2' } }
+        }
+      }
+    });
+  }
+
+  function renderBreakdowns(src, breakdowns) {
+    els.breakdownGrid.innerHTML = src.breakdowns.map(function (b) {
+      var rows = breakdowns[b.key] || [];
+      var max = rows.reduce(function (m, r) { return Math.max(m, r.count); }, 0) || 1;
+      var body = rows.length ? rows.map(function (r) {
+        var pct = Math.round((r.count / max) * 100);
+        return '<div class="bar-row"><span class="bar-row__fill" style="width:' + pct + '%"></span>' +
+          '<span class="bar-row__key" title="' + esc(r.key) + '">' + esc(r.key || '—') + '</span>' +
+          '<span class="bar-row__count">' + fmt(r.count) + '</span></div>';
+      }).join('') : '<div class="panel__empty">No data in range.</div>';
+      return '<div class="panel"><h3>' + esc(b.title) + '</h3><div class="panel__body">' + body + '</div></div>';
+    }).join('');
+  }
+
+  function renderFilters(src, meta) {
+    var html = src.filters.map(function (f) {
+      var opts = (meta[f.metaKey] || []).map(function (v) {
+        var sel = state.filters[f.param] === v ? ' selected' : '';
+        return '<option value="' + esc(v) + '"' + sel + '>' + esc(v) + '</option>';
+      }).join('');
+      return '<select data-param="' + f.param + '"><option value="">' + esc(f.label) + ': all</option>' + opts + '</select>';
+    }).join('');
+    els.filterBar.innerHTML = html;
+    Array.prototype.forEach.call(els.filterBar.querySelectorAll('select'), function (sel) {
+      sel.addEventListener('change', function () {
+        state.filters[sel.getAttribute('data-param')] = sel.value;
+        state.page = 1;
+        refresh();
+      });
+    });
+  }
+
+  function renderTable(src, data) {
+    var thead = '<tr>' + src.columns.map(function (c) { return '<th>' + esc(c.label) + '</th>'; }).join('') + '</tr>';
+    els.eventsTable.querySelector('thead').innerHTML = thead;
+    var rows = data.results || [];
+    var body = rows.length ? rows.map(function (row) {
+      return '<tr>' + src.columns.map(function (c) {
+        var val = row[c.key];
+        if (c.time) val = formatTime(val);
+        else if (c.json) return '<td class="props"><code>' + esc(JSON.stringify(val || {})) + '</code></td>';
+        return '<td>' + esc(val == null || val === '' ? '—' : val) + '</td>';
+      }).join('') + '</tr>';
+    }).join('') : '<tr><td colspan="' + src.columns.length + '" class="panel__empty">No events in range.</td></tr>';
+    els.eventsTable.querySelector('tbody').innerHTML = body;
+
+    var totalPages = data.total_pages || 1;
+    els.pageLabel.textContent = 'Page ' + (data.page || 1) + ' / ' + totalPages + ' · ' + fmt(data.count || 0) + ' rows';
+    els.prevPage.disabled = (data.page || 1) <= 1;
+    els.nextPage.disabled = (data.page || 1) >= totalPages;
+  }
+
+  /* --- formatting --- */
+  function labelFor(iso, interval) {
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    if (interval === 'hour') return pad(d.getHours()) + ':00';
+    if (interval === 'month') return d.toLocaleString(undefined, { month: 'short', year: '2-digit' });
+    return d.toLocaleString(undefined, { month: 'short', day: 'numeric' });
+  }
+  function formatTime(iso) {
+    if (!iso) return '—';
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' });
+  }
+  function fmt(n) { return (n || 0).toLocaleString(); }
+  function esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+  function setError(msg) {
+    els.errorBanner.hidden = !msg;
+    els.errorBanner.textContent = msg || '';
+  }
+  function setConn(s) {
+    els.connectionDot.className = 'conn conn--' + (s === 'ok' ? 'ok' : 'err');
+  }
+})();

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -141,6 +141,7 @@ td.props { max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
 
 /* Modal */
 .modal { position: fixed; inset: 0; background: rgba(15,23,42,0.45); display: flex; align-items: center; justify-content: center; z-index: 50; padding: 1rem; }
+.modal[hidden] { display: none; } /* beat the [hidden] vs display:flex specificity clash */
 .modal__panel { background: var(--card); border-radius: var(--radius); width: 100%; max-width: 440px; box-shadow: 0 20px 50px rgba(0,0,0,0.25); }
 .modal__head, .modal__foot { padding: 1rem 1.2rem; }
 .modal__head { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--line); }

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,0 +1,157 @@
+:root {
+  --green: #218732;
+  --green-dark: #15803d;
+  --green-soft: #dcfce7;
+  --amber: #ffc107;
+  --ink: #1a1a1a;
+  --muted: #6b7280;
+  --line: #e5e7eb;
+  --bg: #f5f6f6;
+  --card: #ffffff;
+  --shadow: 0 1px 2px rgba(16, 24, 40, 0.05), 0 1px 3px rgba(16, 24, 40, 0.04);
+  --radius: 14px;
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  color: var(--ink);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1, h2 { margin: 0; }
+code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.85em; }
+.muted { color: var(--muted); font-size: 0.85rem; }
+
+/* Topbar */
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.85rem 1.5rem;
+  background: var(--card);
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.topbar__brand { display: flex; align-items: center; gap: 0.7rem; }
+.topbar__brand h1 { font-size: 1.05rem; line-height: 1.1; }
+.topbar__brand p { margin: 0; font-size: 0.78rem; color: var(--muted); }
+.topbar__dot {
+  width: 34px; height: 34px; border-radius: 10px;
+  background: linear-gradient(135deg, var(--green), var(--green-dark));
+  box-shadow: inset 0 0 0 3px rgba(255,255,255,0.25);
+}
+.topbar__actions { margin-left: auto; display: flex; align-items: center; gap: 0.75rem; }
+
+.conn { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
+.conn--idle { background: var(--line); }
+.conn--ok { background: var(--green); box-shadow: 0 0 0 3px var(--green-soft); }
+.conn--err { background: #b91c1c; box-shadow: 0 0 0 3px #fee2e2; }
+
+/* Tabs */
+.tabs { display: flex; gap: 0.25rem; background: var(--bg); padding: 0.25rem; border-radius: 10px; }
+.tab {
+  border: 0; background: transparent; cursor: pointer;
+  padding: 0.4rem 0.9rem; border-radius: 8px; font-weight: 600; font-size: 0.85rem;
+  color: var(--muted);
+}
+.tab.is-active { background: var(--card); color: var(--ink); box-shadow: var(--shadow); }
+
+/* Buttons */
+.btn {
+  border: 1px solid var(--line); background: var(--card); color: var(--ink);
+  border-radius: 9px; padding: 0.5rem 0.9rem; font-weight: 600; font-size: 0.85rem;
+  cursor: pointer; transition: background 0.15s, border-color 0.15s;
+}
+.btn:hover { border-color: #d1d5db; }
+.btn--primary { background: var(--green); border-color: var(--green); color: #fff; }
+.btn--primary:hover { background: var(--green-dark); border-color: var(--green-dark); }
+.btn--ghost { background: transparent; }
+.btn--sm { padding: 0.3rem 0.6rem; font-size: 0.8rem; }
+
+/* Layout */
+.container { max-width: 1180px; margin: 0 auto; padding: 1.5rem; }
+
+.controls {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+.controls__ranges, .controls__dates, .controls__filters { display: flex; gap: 0.4rem; flex-wrap: wrap; align-items: center; }
+.controls__dates label { font-size: 0.8rem; color: var(--muted); display: flex; flex-direction: column; gap: 0.15rem; }
+.controls__filters select, .controls__dates input {
+  border: 1px solid var(--line); border-radius: 8px; padding: 0.4rem 0.5rem; font: inherit; font-size: 0.83rem; background: var(--card);
+}
+.controls > .btn--primary { margin-left: auto; }
+.chip {
+  border: 1px solid var(--line); background: var(--card); border-radius: 999px;
+  padding: 0.35rem 0.8rem; cursor: pointer; font-size: 0.82rem; font-weight: 600; color: var(--muted);
+}
+.chip.is-active { background: var(--green-soft); border-color: var(--green); color: var(--green-dark); }
+
+/* Cards */
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin-bottom: 1.25rem; }
+.metric {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  padding: 1.1rem 1.2rem; box-shadow: var(--shadow);
+}
+.metric__label { font-size: 0.78rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; }
+.metric__value { font-size: 2rem; font-weight: 700; margin-top: 0.3rem; }
+
+.card {
+  background: var(--card); border: 1px solid var(--line); border-radius: var(--radius);
+  box-shadow: var(--shadow); margin-bottom: 1.25rem;
+}
+.card__head { display: flex; align-items: center; justify-content: space-between; padding: 1rem 1.2rem; border-bottom: 1px solid var(--line); }
+.card__head h2 { font-size: 0.95rem; }
+
+.chart-wrap { padding: 1rem 1.2rem; height: 300px; }
+canvas { max-width: 100%; }
+
+/* Breakdown grid */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 1.25rem; margin-bottom: 1.25rem; }
+.panel { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); box-shadow: var(--shadow); }
+.panel h3 { font-size: 0.85rem; margin: 0; padding: 0.85rem 1.1rem; border-bottom: 1px solid var(--line); }
+.panel__body { padding: 0.4rem 1.1rem 0.9rem; }
+.bar-row { position: relative; display: flex; justify-content: space-between; align-items: center; padding: 0.45rem 0.6rem; font-size: 0.85rem; border-radius: 8px; overflow: hidden; }
+.bar-row + .bar-row { margin-top: 0.2rem; }
+.bar-row__fill { position: absolute; inset: 0 auto 0 0; background: var(--green-soft); border-radius: 8px; z-index: 0; }
+.bar-row__key, .bar-row__count { position: relative; z-index: 1; }
+.bar-row__key { font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 75%; }
+.bar-row__count { font-variant-numeric: tabular-nums; color: var(--green-dark); font-weight: 700; }
+.panel__empty { color: var(--muted); font-size: 0.85rem; padding: 0.8rem 0.6rem; }
+
+/* Table */
+.table-scroll { overflow-x: auto; }
+table { width: 100%; border-collapse: collapse; font-size: 0.83rem; }
+th, td { text-align: left; padding: 0.6rem 1.2rem; border-bottom: 1px solid var(--line); white-space: nowrap; }
+th { color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 0.72rem; letter-spacing: 0.03em; }
+td.props { max-width: 320px; overflow: hidden; text-overflow: ellipsis; }
+.pager { display: flex; align-items: center; gap: 0.6rem; }
+
+.banner { padding: 0.8rem 1.1rem; border-radius: var(--radius); margin-bottom: 1.25rem; font-size: 0.88rem; }
+.banner--error { background: #fee2e2; color: #b91c1c; border: 1px solid #fecaca; }
+
+.footer { text-align: center; color: var(--muted); font-size: 0.8rem; padding: 1rem 0 2rem; }
+
+/* Modal */
+.modal { position: fixed; inset: 0; background: rgba(15,23,42,0.45); display: flex; align-items: center; justify-content: center; z-index: 50; padding: 1rem; }
+.modal__panel { background: var(--card); border-radius: var(--radius); width: 100%; max-width: 440px; box-shadow: 0 20px 50px rgba(0,0,0,0.25); }
+.modal__head, .modal__foot { padding: 1rem 1.2rem; }
+.modal__head { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid var(--line); }
+.modal__head h2 { font-size: 1rem; }
+.modal__body { padding: 1.1rem 1.2rem; display: flex; flex-direction: column; gap: 0.9rem; }
+.modal__foot { border-top: 1px solid var(--line); text-align: right; }
+.field { display: flex; flex-direction: column; gap: 0.3rem; font-size: 0.83rem; font-weight: 600; }
+.field input { border: 1px solid var(--line); border-radius: 9px; padding: 0.55rem 0.65rem; font: inherit; }
+.field__hint { font-weight: 400; }
+
+@media (max-width: 640px) {
+  .topbar { flex-wrap: wrap; gap: 0.75rem; }
+  .controls > .btn--primary { margin-left: 0; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>São Miguel Hub · Analytics</title>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" />
+  <link rel="stylesheet" href="./assets/styles.css" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="topbar__brand">
+      <span class="topbar__dot"></span>
+      <div>
+        <h1>São Miguel Hub</h1>
+        <p>Analytics dashboard</p>
+      </div>
+    </div>
+
+    <nav class="tabs" role="tablist" aria-label="Data source">
+      <button class="tab is-active" data-source="v3" role="tab">Hub (v3)</button>
+      <button class="tab" data-source="legacy" role="tab">Legacy</button>
+    </nav>
+
+    <div class="topbar__actions">
+      <span id="connectionDot" class="conn conn--idle" title="API status"></span>
+      <button id="settingsBtn" class="btn btn--ghost" type="button" aria-label="Settings">⚙ Settings</button>
+    </div>
+  </header>
+
+  <main class="container">
+    <section class="controls" aria-label="Filters">
+      <div class="controls__ranges" id="rangePresets">
+        <button class="chip" data-range="1">24h</button>
+        <button class="chip is-active" data-range="7">7d</button>
+        <button class="chip" data-range="30">30d</button>
+        <button class="chip" data-range="90">90d</button>
+        <button class="chip" data-range="365">1y</button>
+      </div>
+      <div class="controls__dates">
+        <label>From <input type="date" id="startDate" /></label>
+        <label>To <input type="date" id="endDate" /></label>
+      </div>
+      <div class="controls__filters" id="filterBar"></div>
+      <button id="refreshBtn" class="btn btn--primary" type="button">Refresh</button>
+    </section>
+
+    <div id="errorBanner" class="banner banner--error" hidden></div>
+
+    <section class="cards" id="metricCards" aria-label="Key metrics"></section>
+
+    <section class="card chart-card">
+      <header class="card__head">
+        <h2 id="seriesTitle">Activity over time</h2>
+        <span class="muted" id="seriesInterval"></span>
+      </header>
+      <div class="chart-wrap"><canvas id="seriesChart"></canvas></div>
+    </section>
+
+    <section class="grid" id="breakdownGrid" aria-label="Breakdowns"></section>
+
+    <section class="card table-card">
+      <header class="card__head">
+        <h2>Raw events</h2>
+        <div class="pager">
+          <button id="prevPage" class="btn btn--ghost btn--sm" type="button">‹ Prev</button>
+          <span id="pageLabel" class="muted">–</span>
+          <button id="nextPage" class="btn btn--ghost btn--sm" type="button">Next ›</button>
+        </div>
+      </header>
+      <div class="table-scroll">
+        <table id="eventsTable">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <footer class="footer">
+      <span>Static dashboard · queries <code id="footerApi">api</code> · data stays in your browser</span>
+    </footer>
+  </main>
+
+  <div id="settingsModal" class="modal" hidden>
+    <div class="modal__panel" role="dialog" aria-modal="true" aria-labelledby="settingsTitle">
+      <header class="modal__head">
+        <h2 id="settingsTitle">Connection settings</h2>
+        <button id="settingsClose" class="btn btn--ghost btn--sm" type="button" aria-label="Close">✕</button>
+      </header>
+      <div class="modal__body">
+        <label class="field">
+          <span>API base URL</span>
+          <input type="url" id="apiBase" placeholder="https://api.saomiguelbus.com" />
+        </label>
+        <label class="field">
+          <span>AUTH key</span>
+          <input type="password" id="authKey" placeholder="AUTH_KEY" autocomplete="off" />
+        </label>
+        <label class="field">
+          <span>Island key</span>
+          <input type="text" id="islandKey" placeholder="sao-miguel" />
+        </label>
+        <p class="muted field__hint">
+          Stored only in this browser's <code>localStorage</code>. The AUTH key is sent
+          as the <code>X-Auth-Key</code> header to the analytics reporting API.
+        </p>
+      </div>
+      <footer class="modal__foot">
+        <button id="settingsSave" class="btn btn--primary" type="button">Save &amp; reload</button>
+      </footer>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+  <script src="./assets/app.js"></script>
+</body>
+</html>

--- a/src/analytics/api_reporting.py
+++ b/src/analytics/api_reporting.py
@@ -1,0 +1,146 @@
+"""Read-side analytics API (AUTH_KEY protected) for the stats dashboard."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from analytics import services_reporting as reporting
+
+
+def _auth_key_from_request(request: Request) -> str:
+    return (
+        request.query_params.get('key')
+        or request.headers.get('X-Auth-Key')
+        or request.headers.get('X-Api-Key')
+        or ''
+    )
+
+
+def _denied(request: Request) -> Response | None:
+    if _auth_key_from_request(request) != settings.AUTH_KEY:
+        return Response(
+            {'error': {'code': 'unauthorized', 'message': 'Valid AUTH_KEY required'}},
+            status=status.HTTP_401_UNAUTHORIZED,
+        )
+    return None
+
+
+def _require_island(request: Request) -> Response | None:
+    if request.island is None:
+        return Response(
+            {'error': {'code': 'island_required', 'message': 'Island context required'}},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return None
+
+
+def _q(request: Request, name: str) -> str | None:
+    value = request.query_params.get(name)
+    return value.strip() if value and value.strip() else None
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def v3_overview_view(request: Request) -> Response:
+    denied = _denied(request) or _require_island(request)
+    if denied:
+        return denied
+
+    start, end = reporting.parse_range(_q(request, 'start'), _q(request, 'end'))
+    interval = reporting.resolve_interval(start, end, _q(request, 'interval'))
+    payload = reporting.v3_overview(
+        island=request.island,
+        start=start,
+        end=end,
+        interval=interval,
+        module=_q(request, 'module'),
+        event_type=_q(request, 'event_type'),
+        platform=_q(request, 'platform'),
+    )
+    return Response(payload)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def v3_events_view(request: Request) -> Response:
+    denied = _denied(request) or _require_island(request)
+    if denied:
+        return denied
+
+    start, end = reporting.parse_range(_q(request, 'start'), _q(request, 'end'))
+    page, page_size = reporting.paginate_params(_q(request, 'page'), _q(request, 'page_size'))
+    payload = reporting.v3_events(
+        island=request.island,
+        start=start,
+        end=end,
+        page=page,
+        page_size=page_size,
+        module=_q(request, 'module'),
+        event_type=_q(request, 'event_type'),
+        platform=_q(request, 'platform'),
+    )
+    return Response(payload)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def v3_meta_view(request: Request) -> Response:
+    denied = _denied(request) or _require_island(request)
+    if denied:
+        return denied
+    return Response(reporting.v3_meta(request.island))
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def legacy_overview_view(request: Request) -> Response:
+    denied = _denied(request)
+    if denied:
+        return denied
+
+    start, end = reporting.parse_range(_q(request, 'start'), _q(request, 'end'))
+    interval = reporting.resolve_interval(start, end, _q(request, 'interval'))
+    payload = reporting.legacy_overview(
+        start=start,
+        end=end,
+        interval=interval,
+        request_type=_q(request, 'request'),
+        platform=_q(request, 'platform'),
+        language=_q(request, 'language'),
+    )
+    return Response(payload)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def legacy_events_view(request: Request) -> Response:
+    denied = _denied(request)
+    if denied:
+        return denied
+
+    start, end = reporting.parse_range(_q(request, 'start'), _q(request, 'end'))
+    page, page_size = reporting.paginate_params(_q(request, 'page'), _q(request, 'page_size'))
+    payload = reporting.legacy_events(
+        start=start,
+        end=end,
+        page=page,
+        page_size=page_size,
+        request_type=_q(request, 'request'),
+        platform=_q(request, 'platform'),
+        language=_q(request, 'language'),
+    )
+    return Response(payload)
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def legacy_meta_view(request: Request) -> Response:
+    denied = _denied(request)
+    if denied:
+        return denied
+    return Response(reporting.legacy_meta())

--- a/src/analytics/services_reporting.py
+++ b/src/analytics/services_reporting.py
@@ -1,0 +1,361 @@
+"""Read-side analytics aggregation for the stats dashboard.
+
+Aggregates both the v3 ``AnalyticsEvent`` stream (consent-gated, tenant scoped)
+and the legacy ``Stat`` table (global, compat ingestion) into umami-style
+overview payloads plus paginated raw rows.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+from django.db.models import Count, Max, Min, Q, QuerySet
+from django.db.models.functions import TruncDay, TruncHour, TruncMonth
+from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
+
+from analytics.models import AnalyticsEvent, Stat
+from tenancy.models import Island
+
+DEFAULT_RANGE_DAYS = 30
+MAX_PAGE_SIZE = 500
+DEFAULT_PAGE_SIZE = 50
+BREAKDOWN_LIMIT = 20
+
+_TRUNCATORS = {
+    'hour': TruncHour,
+    'day': TruncDay,
+    'month': TruncMonth,
+}
+
+
+def parse_range(
+    start_raw: str | None,
+    end_raw: str | None,
+) -> tuple[datetime, datetime]:
+    """Resolve a [start, end) window, defaulting to the last 30 days."""
+    end = _parse_dt(end_raw, end_of_day=True) or timezone.now()
+    start = _parse_dt(start_raw) or (end - timedelta(days=DEFAULT_RANGE_DAYS))
+    if start > end:
+        start, end = end, start
+    return start, end
+
+
+def resolve_interval(start: datetime, end: datetime, requested: str | None) -> str:
+    """Pick a time-series bucket size, honouring an explicit request when valid."""
+    if requested in _TRUNCATORS:
+        return requested
+    span = end - start
+    if span <= timedelta(days=2):
+        return 'hour'
+    if span <= timedelta(days=92):
+        return 'day'
+    return 'month'
+
+
+def paginate_params(page_raw: str | None, page_size_raw: str | None) -> tuple[int, int]:
+    page = max(_to_int(page_raw, 1), 1)
+    page_size = _to_int(page_size_raw, DEFAULT_PAGE_SIZE)
+    page_size = max(1, min(page_size, MAX_PAGE_SIZE))
+    return page, page_size
+
+
+# --- v3 AnalyticsEvent -------------------------------------------------------
+
+def v3_overview(
+    *,
+    island: Island,
+    start: datetime,
+    end: datetime,
+    interval: str,
+    module: str | None = None,
+    event_type: str | None = None,
+    platform: str | None = None,
+) -> dict[str, Any]:
+    qs = _v3_queryset(island, start, end, module, event_type, platform)
+
+    totals = qs.aggregate(
+        events=Count('id'),
+        sessions=Count('session_hash', distinct=True, filter=Q(session_hash__gt='')),
+    )
+
+    trunc = _TRUNCATORS[interval]
+    series_rows = (
+        qs.annotate(bucket=trunc('occurred_at'))
+        .values('bucket')
+        .annotate(
+            events=Count('id'),
+            sessions=Count('session_hash', distinct=True, filter=Q(session_hash__gt='')),
+        )
+        .order_by('bucket')
+    )
+    series = [
+        {
+            'bucket': _iso(row['bucket']),
+            'events': row['events'],
+            'sessions': row['sessions'],
+        }
+        for row in series_rows
+    ]
+
+    return {
+        'range': {'start': _iso(start), 'end': _iso(end), 'interval': interval},
+        'totals': {
+            'events': totals['events'] or 0,
+            'sessions': totals['sessions'] or 0,
+        },
+        'series': series,
+        'breakdowns': {
+            'module': _breakdown(qs, 'module'),
+            'event_type': _breakdown(qs, 'event_type'),
+            'platform': _breakdown(qs, 'platform'),
+            'locale': _breakdown(qs, 'locale'),
+        },
+    }
+
+
+def v3_events(
+    *,
+    island: Island,
+    start: datetime,
+    end: datetime,
+    page: int,
+    page_size: int,
+    module: str | None = None,
+    event_type: str | None = None,
+    platform: str | None = None,
+) -> dict[str, Any]:
+    qs = _v3_queryset(island, start, end, module, event_type, platform)
+    count = qs.count()
+    offset = (page - 1) * page_size
+    rows = qs.order_by('-occurred_at')[offset:offset + page_size]
+    results = [
+        {
+            'id': row.id,
+            'module': row.module,
+            'event_type': row.event_type,
+            'properties': row.properties,
+            'platform': row.platform,
+            'locale': row.locale,
+            'app_version': row.app_version,
+            'session_hash': row.session_hash,
+            'occurred_at': _iso(row.occurred_at),
+        }
+        for row in rows
+    ]
+    return _page_envelope(count, page, page_size, results)
+
+
+def v3_meta(island: Island) -> dict[str, Any]:
+    qs = AnalyticsEvent.objects.for_island(island)
+    bounds = qs.aggregate(first=Min('occurred_at'), last=Max('occurred_at'))
+    return {
+        'modules': _distinct(qs, 'module'),
+        'event_types': _distinct(qs, 'event_type'),
+        'platforms': _distinct(qs, 'platform'),
+        'locales': _distinct(qs, 'locale'),
+        'first_event': _iso(bounds['first']),
+        'last_event': _iso(bounds['last']),
+        'total': qs.count(),
+    }
+
+
+# --- legacy Stat -------------------------------------------------------------
+
+def legacy_overview(
+    *,
+    start: datetime,
+    end: datetime,
+    interval: str,
+    request_type: str | None = None,
+    platform: str | None = None,
+    language: str | None = None,
+) -> dict[str, Any]:
+    qs = _legacy_queryset(start, end, request_type, platform, language)
+
+    totals = qs.aggregate(
+        stats=Count('id'),
+        routes=Count('id', filter=~Q(origin='') & ~Q(destination='')),
+    )
+
+    trunc = _TRUNCATORS[interval]
+    series_rows = (
+        qs.annotate(bucket=trunc('timestamp'))
+        .values('bucket')
+        .annotate(count=Count('id'))
+        .order_by('bucket')
+    )
+    series = [{'bucket': _iso(row['bucket']), 'count': row['count']} for row in series_rows]
+
+    route_rows = (
+        qs.exclude(origin='')
+        .exclude(destination='')
+        .values('origin', 'destination')
+        .annotate(count=Count('id'))
+        .order_by('-count')[:BREAKDOWN_LIMIT]
+    )
+    top_routes = [
+        {
+            'key': f"{row['origin']} \u2192 {row['destination']}",
+            'origin': row['origin'],
+            'destination': row['destination'],
+            'count': row['count'],
+        }
+        for row in route_rows
+    ]
+
+    return {
+        'range': {'start': _iso(start), 'end': _iso(end), 'interval': interval},
+        'totals': {
+            'stats': totals['stats'] or 0,
+            'routes': totals['routes'] or 0,
+        },
+        'series': series,
+        'breakdowns': {
+            'request': _breakdown(qs, 'request'),
+            'platform': _breakdown(qs, 'platform'),
+            'language': _breakdown(qs, 'language'),
+            'type_of_day': _breakdown(qs, 'type_of_day'),
+            'top_origins': _breakdown(qs.exclude(origin=''), 'origin'),
+            'top_destinations': _breakdown(qs.exclude(destination=''), 'destination'),
+            'top_routes': top_routes,
+        },
+    }
+
+
+def legacy_events(
+    *,
+    start: datetime,
+    end: datetime,
+    page: int,
+    page_size: int,
+    request_type: str | None = None,
+    platform: str | None = None,
+    language: str | None = None,
+) -> dict[str, Any]:
+    qs = _legacy_queryset(start, end, request_type, platform, language)
+    count = qs.count()
+    offset = (page - 1) * page_size
+    rows = qs.order_by('-timestamp', '-id')[offset:offset + page_size]
+    results = [
+        {
+            'id': row.id,
+            'request': row.request,
+            'origin': row.origin,
+            'destination': row.destination,
+            'type_of_day': row.type_of_day,
+            'time': row.time,
+            'platform': row.platform,
+            'language': row.language,
+            'timestamp': _iso(row.timestamp),
+        }
+        for row in rows
+    ]
+    return _page_envelope(count, page, page_size, results)
+
+
+def legacy_meta() -> dict[str, Any]:
+    qs = Stat.objects.all()
+    bounds = qs.aggregate(first=Min('timestamp'), last=Max('timestamp'))
+    return {
+        'requests': _distinct(qs, 'request'),
+        'platforms': _distinct(qs, 'platform'),
+        'languages': _distinct(qs, 'language'),
+        'first_event': _iso(bounds['first']),
+        'last_event': _iso(bounds['last']),
+        'total': qs.count(),
+    }
+
+
+# --- internals ---------------------------------------------------------------
+
+def _v3_queryset(
+    island: Island,
+    start: datetime,
+    end: datetime,
+    module: str | None,
+    event_type: str | None,
+    platform: str | None,
+) -> QuerySet:
+    qs = AnalyticsEvent.objects.for_island(island).filter(
+        occurred_at__gte=start, occurred_at__lte=end
+    )
+    if module:
+        qs = qs.filter(module=module)
+    if event_type:
+        qs = qs.filter(event_type=event_type)
+    if platform:
+        qs = qs.filter(platform=platform)
+    return qs
+
+
+def _legacy_queryset(
+    start: datetime,
+    end: datetime,
+    request_type: str | None,
+    platform: str | None,
+    language: str | None,
+) -> QuerySet:
+    qs = Stat.objects.filter(timestamp__gte=start, timestamp__lte=end)
+    if request_type:
+        qs = qs.filter(request=request_type)
+    if platform:
+        qs = qs.filter(platform=platform)
+    if language:
+        qs = qs.filter(language=language)
+    return qs
+
+
+def _breakdown(qs: QuerySet, field: str, limit: int = BREAKDOWN_LIMIT) -> list[dict[str, Any]]:
+    rows = qs.values(field).annotate(count=Count('id')).order_by('-count')[:limit]
+    return [{'key': row[field] or '', 'count': row['count']} for row in rows]
+
+
+def _distinct(qs: QuerySet, field: str) -> list[str]:
+    values = qs.exclude(**{field: ''}).values_list(field, flat=True).distinct().order_by(field)
+    return [v for v in values if v]
+
+
+def _page_envelope(count: int, page: int, page_size: int, results: list) -> dict[str, Any]:
+    total_pages = (count + page_size - 1) // page_size if page_size else 0
+    return {
+        'count': count,
+        'page': page,
+        'page_size': page_size,
+        'total_pages': total_pages,
+        'results': results,
+    }
+
+
+def _parse_dt(raw: str | None, *, end_of_day: bool = False) -> datetime | None:
+    if not raw:
+        return None
+    raw = raw.strip()
+    parsed = parse_datetime(raw)
+    if parsed is None:
+        day = parse_date(raw)
+        if day is None:
+            return None
+        time_part = (
+            datetime.max.time().replace(microsecond=0)
+            if end_of_day
+            else datetime.min.time()
+        )
+        parsed = datetime.combine(day, time_part)
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed)
+    return parsed
+
+
+def _to_int(raw: str | None, default: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _iso(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()

--- a/src/analytics/tests/test_reporting.py
+++ b/src/analytics/tests/test_reporting.py
@@ -1,0 +1,131 @@
+"""Tests for the read-side analytics reporting API."""
+
+from datetime import timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from analytics.models import AnalyticsEvent, Stat
+from tenancy.services import get_or_create_default_island
+
+AUTH = 'test-reporting-key'
+
+
+@override_settings(AUTH_KEY=AUTH)
+class ReportingApiTests(TestCase):
+    def setUp(self):
+        self.island = get_or_create_default_island()
+        now = timezone.now()
+
+        for i in range(5):
+            AnalyticsEvent.objects.create(
+                island=self.island,
+                module='transit',
+                event_type='search',
+                properties={'origin': 'PDL'},
+                session_hash=f'sess-{i % 2}',
+                consent_state={'analytics': True},
+                platform='web',
+                locale='pt',
+                occurred_at=now - timedelta(days=i),
+            )
+        AnalyticsEvent.objects.create(
+            island=self.island,
+            module='news',
+            event_type='open',
+            properties={},
+            session_hash='sess-news',
+            consent_state={'analytics': True},
+            platform='ios',
+            locale='en',
+            occurred_at=now - timedelta(days=1),
+        )
+
+        for i in range(4):
+            Stat.objects.create(
+                request='GET_ROUTE',
+                origin='Ponta Delgada',
+                destination='Ribeira Grande',
+                platform='web',
+                language='pt',
+                type_of_day='WEEKDAY',
+            )
+        Stat.objects.create(
+            request='GET_DIRECTIONS',
+            origin='Lagoa',
+            destination='Furnas',
+            platform='android',
+            language='en',
+            type_of_day='WEEKEND',
+        )
+
+    def _get(self, path, **params):
+        params.setdefault('key', AUTH)
+        return self.client.get(path, params, HTTP_X_ISLAND=self.island.key)
+
+    def test_requires_auth_key(self):
+        resp = self.client.get('/api/v3/analytics/reports/overview', HTTP_X_ISLAND=self.island.key)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_v3_overview_totals_and_breakdowns(self):
+        resp = self._get('/api/v3/analytics/reports/overview')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['totals']['events'], 6)
+        # sess-0, sess-1, sess-news distinct
+        self.assertEqual(data['totals']['sessions'], 3)
+        modules = {row['key']: row['count'] for row in data['breakdowns']['module']}
+        self.assertEqual(modules['transit'], 5)
+        self.assertEqual(modules['news'], 1)
+        platforms = {row['key']: row['count'] for row in data['breakdowns']['platform']}
+        self.assertEqual(platforms['web'], 5)
+        self.assertEqual(platforms['ios'], 1)
+        self.assertTrue(len(data['series']) >= 1)
+
+    def test_v3_overview_module_filter(self):
+        resp = self._get('/api/v3/analytics/reports/overview', module='news')
+        data = resp.json()
+        self.assertEqual(data['totals']['events'], 1)
+
+    def test_v3_events_pagination(self):
+        resp = self._get('/api/v3/analytics/reports/events', page_size=2)
+        data = resp.json()
+        self.assertEqual(data['count'], 6)
+        self.assertEqual(len(data['results']), 2)
+        self.assertEqual(data['total_pages'], 3)
+        self.assertIn('occurred_at', data['results'][0])
+
+    def test_v3_meta(self):
+        resp = self._get('/api/v3/analytics/reports/meta')
+        data = resp.json()
+        self.assertIn('transit', data['modules'])
+        self.assertIn('news', data['modules'])
+        self.assertEqual(data['total'], 6)
+
+    def test_legacy_overview_routes(self):
+        resp = self._get('/api/v3/analytics/reports/legacy/overview')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data['totals']['stats'], 5)
+        self.assertEqual(data['totals']['routes'], 5)
+        top = data['breakdowns']['top_routes'][0]
+        self.assertEqual(top['origin'], 'Ponta Delgada')
+        self.assertEqual(top['count'], 4)
+        requests_bd = {row['key']: row['count'] for row in data['breakdowns']['request']}
+        self.assertEqual(requests_bd['GET_ROUTE'], 4)
+
+    def test_legacy_overview_does_not_require_island(self):
+        resp = self.client.get('/api/v3/analytics/reports/legacy/overview', {'key': AUTH})
+        self.assertEqual(resp.status_code, 200)
+
+    def test_legacy_events_filter(self):
+        resp = self._get('/api/v3/analytics/reports/legacy/events', request='GET_DIRECTIONS')
+        data = resp.json()
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['results'][0]['request'], 'GET_DIRECTIONS')
+
+    def test_legacy_meta(self):
+        resp = self._get('/api/v3/analytics/reports/legacy/meta')
+        data = resp.json()
+        self.assertIn('GET_ROUTE', data['requests'])
+        self.assertEqual(data['total'], 5)

--- a/src/analytics/urls_v3.py
+++ b/src/analytics/urls_v3.py
@@ -1,7 +1,22 @@
 from django.urls import path
 
+from analytics.api_reporting import (
+    legacy_events_view,
+    legacy_meta_view,
+    legacy_overview_view,
+    v3_events_view,
+    v3_meta_view,
+    v3_overview_view,
+)
 from analytics.api_v3 import analytics_events_view
 
 urlpatterns = [
     path('events', analytics_events_view, name='v3-analytics-events'),
+    # Read-side reporting (AUTH_KEY protected) — powers the stats dashboard.
+    path('reports/overview', v3_overview_view, name='v3-analytics-overview'),
+    path('reports/events', v3_events_view, name='v3-analytics-report-events'),
+    path('reports/meta', v3_meta_view, name='v3-analytics-meta'),
+    path('reports/legacy/overview', legacy_overview_view, name='v3-analytics-legacy-overview'),
+    path('reports/legacy/events', legacy_events_view, name='v3-analytics-legacy-events'),
+    path('reports/legacy/meta', legacy_meta_view, name='v3-analytics-legacy-meta'),
 ]

--- a/src/src/settings.py
+++ b/src/src/settings.py
@@ -86,6 +86,9 @@ CORS_ALLOW_HEADERS = (
     *default_headers,
     'x-island',
     'x-session-id',
+    # Analytics stats dashboard (GitHub Pages) authenticates with these.
+    'x-auth-key',
+    'x-api-key',
 )
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

We were ingesting analytics but had no way to read them back. This adds:

1. **Read-side reporting API** (`/api/v3/analytics/reports/*`) — AUTH_KEY protected.
2. **A static, umami-style dashboard** under `docs/` for GitHub Pages, covering both the v3 Hub stream and the legacy `Stat` data.

## Walkthrough

[analytics_dashboard_demo.mp4](https://cursor.com/agents/bc-b23c5078-2072-4b0a-9cd5-a520f4d38802/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanalytics_dashboard_demo.mp4)

Demo: Hub (v3) overview → 30d range → scroll breakdowns + raw table → Legacy tab (Requests / Top routes) → `GET_DIRECTIONS` filter → back to Hub.

[Hub v3 dashboard](https://cursor.com/agents/bc-b23c5078-2072-4b0a-9cd5-a520f4d38802/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_hub_v3.webp)
[Legacy dashboard](https://cursor.com/agents/bc-b23c5078-2072-4b0a-9cd5-a520f4d38802/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_legacy.webp)

## API

All endpoints require `AUTH_KEY` via the `X-Auth-Key` header (or `?key=`). v3 endpoints are tenant-scoped via `X-Island`.

| Endpoint | Purpose |
|----------|---------|
| `GET /api/v3/analytics/reports/overview` | v3 totals, time series, breakdowns (module, event_type, platform, locale) |
| `GET /api/v3/analytics/reports/events` | v3 raw events (paginated, filterable) |
| `GET /api/v3/analytics/reports/meta` | v3 distinct filter values + date bounds |
| `GET /api/v3/analytics/reports/legacy/overview` | legacy totals, series, breakdowns (request, top routes/origins/destinations, platform, language, day type) |
| `GET /api/v3/analytics/reports/legacy/events` | legacy raw stats (paginated) |
| `GET /api/v3/analytics/reports/legacy/meta` | legacy distinct filter values |

Common params: `start`, `end` (`YYYY-MM-DD`), `interval` (`hour|day|month`, auto-selected by range), `page`, `page_size`, plus per-source filters.

- Aggregation logic lives in `analytics/services_reporting.py`; views in `analytics/api_reporting.py`.
- `CORS_ALLOW_HEADERS` now allows `x-auth-key` / `x-api-key` so the Pages dashboard can call cross-origin.

## Dashboard (`docs/`)

Plain HTML/CSS/JS, no build step. Tabs for **Hub (v3)** / **Legacy**, date-range presets (24h → 1y) + custom, time-series bar chart (Chart.js via CDN), breakdown panels, filter dropdowns (from `meta`), and a paginated raw-events table. Connection settings (API base, AUTH key, island) are stored only in the browser's `localStorage`. Ships `.nojekyll` + `docs/README.md` with Pages deploy instructions.

## Testing

- `pytest analytics/` — 10 passed (9 new reporting tests: auth gating, v3 totals/sessions/breakdowns, filters, pagination, meta; legacy routes/breakdowns, island-independence, filters, meta).
- `manage.py check` — clean (only pre-existing unrelated django-axes warning).
- Manual: seeded 1.8k v3 events + 1.2k legacy stats, ran `runserver`, verified all endpoints via curl (correct aggregates, 401 without key) and drove the dashboard in-browser (see demo). Fixed a modal-close CSS bug found during manual testing.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b23c5078-2072-4b0a-9cd5-a520f4d38802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b23c5078-2072-4b0a-9cd5-a520f4d38802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

