### PR TITLE
Fix marketplace provider phone and WhatsApp formatting

### DIFF
--- a/src/marketplace/api_ops.py
+++ b/src/marketplace/api_ops.py
@@ -1,0 +1,55 @@
+"""AUTH_KEY-protected marketplace ops endpoints."""
+
+from __future__ import annotations
+
+from django.conf import settings
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from marketplace import services
+from tenancy.models import Island
+
+
+def _auth_key_from_request(request: Request) -> str:
+    return (
+        request.query_params.get('key')
+        or request.headers.get('X-Auth-Key')
+        or request.headers.get('X-Api-Key')
+        or ''
+    )
+
+
+def _require_auth_key(request: Request) -> Response | None:
+    if _auth_key_from_request(request) != settings.AUTH_KEY:
+        return Response({'error': 'Unauthorized'}, status=401)
+    return None
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def fix_provider_phones_view(request: Request) -> Response:
+    """
+    Normalize provider ``phone`` and ``whatsapp`` values to ``+351XXXXXXXXX``.
+
+    Query params:
+      - key / X-Auth-Key: AUTH_KEY (required)
+      - island: island key slug, e.g. sao-miguel (optional; all islands if omitted)
+      - dry_run: true to preview without saving (default false)
+    """
+    denied = _require_auth_key(request)
+    if denied:
+        return denied
+
+    island_key = (request.query_params.get('island') or '').strip()
+    dry_run = request.query_params.get('dry_run', 'false').lower() in ('1', 'true', 'yes')
+    island = None
+    if island_key:
+        try:
+            island = Island.objects.get(key=island_key)
+        except Island.DoesNotExist:
+            return Response({'error': f'Unknown island key: {island_key}'}, status=400)
+
+    result = services.fix_provider_phone_numbers(island=island, dry_run=dry_run)
+    return Response({'ok': True, **result})

--- a/src/marketplace/management/commands/fix_provider_phones.py
+++ b/src/marketplace/management/commands/fix_provider_phones.py
@@ -1,0 +1,48 @@
+"""Normalize marketplace provider phone and WhatsApp numbers to +351XXXXXXXXX."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from marketplace import services
+from tenancy.models import Island
+
+
+class Command(BaseCommand):
+    help = 'Fix wrongly formatted provider phone and WhatsApp numbers (+351XXXXXXXXX).'
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            '--island',
+            dest='island_key',
+            default='',
+            help='Limit to one island key (e.g. sao-miguel). Default: all islands.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Report changes without writing to the database.',
+        )
+
+    def handle(self, *args, **options) -> None:
+        island_key = (options.get('island_key') or '').strip()
+        dry_run = bool(options.get('dry_run'))
+        island = None
+        if island_key:
+            try:
+                island = Island.objects.get(key=island_key)
+            except Island.DoesNotExist as exc:
+                raise SystemExit(f'Unknown island key: {island_key}') from exc
+
+        result = services.fix_provider_phone_numbers(island=island, dry_run=dry_run)
+        mode = 'DRY RUN' if dry_run else 'APPLIED'
+        self.stdout.write(
+            f'[{mode}] scanned={result["scanned"]} updated={result["updated"]} '
+            f'unchanged={result["unchanged"]} skipped_fields={result["skipped_fields"]}'
+        )
+        for change in result['changes']:
+            parts = [f'#{change["id"]} {change["name"]} ({change["island"]})']
+            for field in ('phone', 'whatsapp'):
+                if field in change:
+                    parts.append(f'{field}: {change[field]["from"]!r} -> {change[field]["to"]!r}')
+            self.stdout.write('  ' + ' | '.join(parts))

--- a/src/marketplace/phone.py
+++ b/src/marketplace/phone.py
@@ -1,0 +1,46 @@
+"""Portuguese phone number normalization for marketplace listings."""
+
+from __future__ import annotations
+
+import re
+
+PT_COUNTRY_CODE = '351'
+PT_NATIONAL_DIGITS = 9
+
+
+def normalize_pt_phone(raw: str | None) -> str | None:
+    """Normalize a phone/WhatsApp value to ``+351XXXXXXXXX``.
+
+    Returns:
+        - ``''`` for empty/whitespace input (unchanged empty).
+        - ``+351`` + 9 national digits when the value can be parsed.
+        - ``None`` when non-empty input cannot be normalized (leave as-is).
+    """
+    if raw is None:
+        return ''
+    text = str(raw).strip()
+    if not text:
+        return ''
+
+    digits = re.sub(r'\D', '', text)
+    if not digits:
+        return None
+
+    if digits.startswith('00'):
+        digits = digits[2:]
+
+    if digits.startswith(PT_COUNTRY_CODE):
+        national = digits[len(PT_COUNTRY_CODE) :]
+        if len(national) == PT_NATIONAL_DIGITS + 1 and national.startswith('0'):
+            national = national[1:]
+        if len(national) == PT_NATIONAL_DIGITS:
+            return f'+{PT_COUNTRY_CODE}{national}'
+        return None
+
+    if len(digits) == PT_NATIONAL_DIGITS + 1 and digits.startswith('0'):
+        digits = digits[1:]
+
+    if len(digits) == PT_NATIONAL_DIGITS:
+        return f'+{PT_COUNTRY_CODE}{digits}'
+
+    return None

--- a/src/marketplace/services.py
+++ b/src/marketplace/services.py
@@ -16,6 +16,7 @@ from django.db.models import Avg, Count
 from django.utils.text import slugify
 
 from marketplace.models import Review, ServiceCategory, ServiceProvider
+from marketplace.phone import normalize_pt_phone
 
 MAX_LIMIT = 100
 DEFAULT_LIMIT = 50
@@ -410,3 +411,75 @@ def recompute_rating(provider: ServiceProvider) -> None:
     provider.rating = Decimal(str(round(avg, 2)))
     provider.review_count = agg['count'] or 0
     provider.save(update_fields=['rating', 'review_count', 'updated_at'])
+
+
+# --------------------------------------------------------------------------- #
+# Phone normalization (one-off / ops)
+# --------------------------------------------------------------------------- #
+
+_PROVIDER_PHONE_FIELDS = ('phone', 'whatsapp')
+
+
+def fix_provider_phone_numbers(
+    *,
+    island=None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Normalize ``phone`` and ``whatsapp`` on all service providers to ``+351XXXXXXXXX``."""
+    qs = ServiceProvider.objects.unscoped().select_related('island')
+    if island is not None:
+        qs = qs.filter(island=island)
+
+    scanned = 0
+    updated = 0
+    unchanged = 0
+    skipped_fields = 0
+    changes: list[dict[str, Any]] = []
+
+    for provider in qs.iterator():
+        scanned += 1
+        field_updates: dict[str, str] = {}
+        field_skipped: list[str] = []
+
+        for field in _PROVIDER_PHONE_FIELDS:
+            raw = getattr(provider, field) or ''
+            if not str(raw).strip():
+                continue
+            normalized = normalize_pt_phone(raw)
+            if normalized is None:
+                field_skipped.append(field)
+                continue
+            if normalized != raw:
+                field_updates[field] = normalized
+
+        if field_skipped:
+            skipped_fields += len(field_skipped)
+
+        if not field_updates:
+            unchanged += 1
+            continue
+
+        updated += 1
+        change_row: dict[str, Any] = {
+            'id': provider.id,
+            'name': provider.name,
+            'island': provider.island.key,
+        }
+        for field, new_value in field_updates.items():
+            change_row[field] = {'from': getattr(provider, field), 'to': new_value}
+        changes.append(change_row)
+
+        if not dry_run:
+            for field, new_value in field_updates.items():
+                setattr(provider, field, new_value)
+            provider.save(update_fields=[*field_updates.keys(), 'updated_at'])
+
+    return {
+        'dry_run': dry_run,
+        'island_key': getattr(island, 'key', None),
+        'scanned': scanned,
+        'updated': updated,
+        'unchanged': unchanged,
+        'skipped_fields': skipped_fields,
+        'changes': changes,
+    }

--- a/src/marketplace/tests/test_phone.py
+++ b/src/marketplace/tests/test_phone.py
@@ -1,0 +1,122 @@
+"""Phone normalization and provider phone fix."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from marketplace import services
+from marketplace.models import ServiceCategory, ServiceProvider
+from marketplace.phone import normalize_pt_phone
+from src import settings as project_settings
+from tenancy.services import get_or_create_default_island
+
+
+class NormalizePtPhoneTests(TestCase):
+    def test_empty(self):
+        self.assertEqual(normalize_pt_phone(''), '')
+        self.assertEqual(normalize_pt_phone(None), '')
+        self.assertEqual(normalize_pt_phone('   '), '')
+
+    def test_already_correct(self):
+        self.assertEqual(normalize_pt_phone('+351912345678'), '+351912345678')
+
+    def test_nine_digit_national(self):
+        self.assertEqual(normalize_pt_phone('912345678'), '+351912345678')
+
+    def test_leading_zero(self):
+        self.assertEqual(normalize_pt_phone('0912345678'), '+351912345678')
+
+    def test_country_code_without_plus(self):
+        self.assertEqual(normalize_pt_phone('351912345678'), '+351912345678')
+
+    def test_international_00_prefix(self):
+        self.assertEqual(normalize_pt_phone('00351912345678'), '+351912345678')
+
+    def test_spaces_and_punctuation(self):
+        self.assertEqual(normalize_pt_phone('+351 912 345 678'), '+351912345678')
+        self.assertEqual(normalize_pt_phone('(91) 234-5678'), '+351912345678')
+
+    def test_country_code_with_trunk_zero(self):
+        self.assertEqual(normalize_pt_phone('3510912345678'), '+351912345678')
+
+    def test_unparseable(self):
+        self.assertIsNone(normalize_pt_phone('123'))
+        self.assertIsNone(normalize_pt_phone('not-a-phone'))
+
+
+class FixProviderPhoneNumbersTests(TestCase):
+    def setUp(self):
+        self.island = get_or_create_default_island()
+        self.category = ServiceCategory.objects.create(
+            island=self.island, name='Other', slug='other'
+        )
+
+    def _provider(self, **fields) -> ServiceProvider:
+        return ServiceProvider.objects.create(
+            island=self.island,
+            category=self.category,
+            name='Test Provider',
+            status=ServiceProvider.PUBLISHED,
+            **fields,
+        )
+
+    def test_fixes_phone_and_whatsapp(self):
+        provider = self._provider(phone='912345678', whatsapp='0911111111')
+        result = services.fix_provider_phone_numbers(dry_run=False)
+        provider.refresh_from_db()
+        self.assertEqual(result['updated'], 1)
+        self.assertEqual(provider.phone, '+351912345678')
+        self.assertEqual(provider.whatsapp, '+351911111111')
+
+    def test_dry_run_does_not_save(self):
+        provider = self._provider(phone='912345678', whatsapp='')
+        services.fix_provider_phone_numbers(dry_run=True)
+        provider.refresh_from_db()
+        self.assertEqual(provider.phone, '912345678')
+
+    def test_leaves_valid_numbers_unchanged(self):
+        provider = self._provider(phone='+351912345678', whatsapp='+351911111111')
+        result = services.fix_provider_phone_numbers(dry_run=False)
+        provider.refresh_from_db()
+        self.assertEqual(result['updated'], 0)
+        self.assertEqual(provider.phone, '+351912345678')
+
+
+@override_settings(AUTH_KEY='test-auth-key')
+class FixProviderPhonesOpsTests(TestCase):
+    def setUp(self):
+        self.auth_patcher = patch.object(project_settings, 'AUTHENTICATION_REQUIRED', False)
+        self.auth_patcher.start()
+        self.addCleanup(self.auth_patcher.stop)
+        self.client = APIClient()
+        self.url = '/api/v1/ops/marketplace/fix-phones'
+        self.island = get_or_create_default_island()
+        self.category = ServiceCategory.objects.create(
+            island=self.island, name='Other', slug='other'
+        )
+        ServiceProvider.objects.create(
+            island=self.island,
+            category=self.category,
+            name='Ops Provider',
+            phone='912345678',
+            whatsapp='351911111111',
+            status=ServiceProvider.PUBLISHED,
+        )
+
+    def test_requires_auth_key(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+    def test_fixes_via_get_endpoint(self):
+        response = self.client.get(f'{self.url}?key={settings.AUTH_KEY}')
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertTrue(body['ok'])
+        self.assertEqual(body['updated'], 1)
+        provider = ServiceProvider.objects.get(name='Ops Provider')
+        self.assertEqual(provider.phone, '+351912345678')
+        self.assertEqual(provider.whatsapp, '+351911111111')

--- a/src/tenancy/urls.py
+++ b/src/tenancy/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from marketplace.api_ops import fix_provider_phones_view
 from tenancy import views
 
 urlpatterns = [
@@ -12,5 +13,10 @@ urlpatterns = [
         'feeds/sync',
         views.trigger_feed_sync,
         name='ops_feed_sync',
+    ),
+    path(
+        'marketplace/fix-phones',
+        fix_provider_phones_view,
+        name='ops_marketplace_fix_phones',
     ),
 ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a one-off data fix for wrongly formatted service provider contact numbers. Both `phone` and `whatsapp` are normalized to `+351XXXXXXXXX` (9 national digits). Values without a country code assume Portugal (`+351`).

## Changes

- `marketplace/phone.py` — normalization helper
- `marketplace/services.py` — `fix_provider_phone_numbers()` batch updater
- `marketplace/management/commands/fix_provider_phones.py` — CLI (`--dry-run`, optional `--island`)
- `GET /api/v1/ops/marketplace/fix-phones` — AUTH_KEY-protected endpoint to run the fix in production
- Tests for normalization, service batch update, and ops endpoint

## Production usage

Preview (no writes):

```
GET https://api.saomiguelbus.com/api/v1/ops/marketplace/fix-phones?key=$AUTH_KEY&dry_run=true
```

Apply fix:

```
GET https://api.saomiguelbus.com/api/v1/ops/marketplace/fix-phones?key=$AUTH_KEY
```

Optional island scope: `&island=sao-miguel`

CLI alternative:

```bash
cd src
python manage.py fix_provider_phones --dry-run
python manage.py fix_provider_phones
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aed6ab39-6928-40fb-9ed6-de00fe0d0d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aed6ab39-6928-40fb-9ed6-de00fe0d0d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

